### PR TITLE
Checking the existence of 40-redhat.rules before modifying

### DIFF
--- a/dracut-module-setup.sh
+++ b/dracut-module-setup.sh
@@ -1013,7 +1013,9 @@ kdump_install_systemd_conf() {
 remove_cpu_online_rule() {
     local file=${initdir}/usr/lib/udev/rules.d/40-redhat.rules
 
-    sed -i '/SUBSYSTEM=="cpu"/d' "$file"
+    if [[ -f $file ]]; then
+        sed -i '/SUBSYSTEM=="cpu"/d' "$file"
+    fi
 }
 
 install() {


### PR DESCRIPTION
Resolves: bz2106645

The code of commit 163c02970e4ddc takes effect in rhel firstly, later
pulled to Fedora. However, Fedora OS doesn't have 40-redhat.rules
in systemd-udev package. With this commit applied, a false positive
warning message can always been seen as below.

So fixing it by checking if 40-redhat.rules exists before handling.
With this change, the false warning is gone.

[root@ ~]# kdumpctl restart
kdump: kexec: unloaded kdump kernel
kdump: Stopping kdump: [OK]
kdump: No kdump initial ramdisk found.
kdump: Rebuilding /boot/initramfs-5.19.0-rc6+kdump.img
sed: can't read /var/tmp/dracut.NnAV2g/initramfs/usr/lib/udev/rules.d/40-redhat.rules: No such file or directory
kdump: kexec: loaded kdump kernel
kdump: Starting kdump: [OK]

Signed-off-by: Baoquan He <bhe@redhat.com>
Acked-by: Pingfan Liu <piliu@redhat.com>