### PR TITLE
use /run/ostree-booted to tell if scriptlet is running on OSTree system

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,54 @@
+name: kexec-tools tests
+
+on:
+    pull_request:
+        branches: [ github_action ]
+
+jobs:
+  format-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: wget https://github.com/mvdan/sh/releases/download/v3.5.1/shfmt_v3.5.1_linux_amd64 -O /usr/local/bin/shfmt && chmod +x /usr/local/bin/shfmt
+      - run: shfmt -d *.sh kdumpctl mk*dumprd
+
+  static-analysis:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      # Currently, for kexec-tools, there is need for shellcheck to require
+      # the sourced file to give correct warnings about the checked file
+      - run: shellcheck --exclude=1090,1091 *.sh spec/*.sh kdumpctl mk*dumprd
+
+  unit-tests:
+    runs-on: ubuntu-latest
+    container: docker.io/fedora:latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: sudo dnf install -y make dracut grubby hostname
+      - run: curl -L -O https://github.com/shellspec/shellspec/archive/latest.tar.gz && tar -xzf latest.tar.gz
+      - run: cd shellspec-latest && sudo make install
+      - run: shellspec
+
+  integration-tests:
+        runs-on: self-hosted
+        timeout-minutes: 45
+        concurrency:
+            group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}
+            cancel-in-progress: true
+        strategy:
+            matrix:
+                container: [
+                        "fedora:35",
+                ]
+            fail-fast: false
+        container:
+            image: ghcr.io/coiby/${{ matrix.container }}
+            options: "--privileged -v /dev:/dev -v /lib/modules:/lib/modules:ro"
+        steps:
+            -   name: "Checkout Repository"
+                uses: actions/checkout@v2
+                with:
+                    fetch-depth: 0
+            -   name: "${{ matrix.container }} kdump tests"
+                run: bash ./tools/run-integration-tests.sh

--- a/dracut-early-kdump-module-setup.sh
+++ b/dracut-early-kdump-module-setup.sh
@@ -23,7 +23,7 @@ prepare_kernel_initrd() {
 
     prepare_kdump_bootinfo
 
-    # $kernel is a variable from dracut
+    # shellcheck disable=SC2154 # $kernel is a variable from dracut
     if [[ $KDUMP_KERNELVER != "$kernel" ]]; then
         dwarn "Using kernel version '$KDUMP_KERNELVER' for early kdump," \
             "but the initramfs is generated for kernel version '$kernel'"
@@ -54,6 +54,7 @@ install() {
     inst_script "/lib/kdump/kdump-lib.sh" "/lib/kdump-lib.sh"
     inst_script "/lib/kdump/kdump-lib-initramfs.sh" "/lib/kdump/kdump-lib-initramfs.sh"
     inst_script "/lib/kdump/kdump-logger.sh" "/lib/kdump-logger.sh"
+    # shellcheck disable=SC2154 # $moddir is a variable from dracut
     inst_hook cmdline 00 "$moddir/early-kdump.sh"
     inst_binary "$KDUMP_KERNEL"
     inst_binary "$KDUMP_INITRD"
@@ -61,5 +62,6 @@ install() {
     ln_r "$KDUMP_KERNEL" "/boot/kernel-earlykdump"
     ln_r "$KDUMP_INITRD" "/boot/initramfs-earlykdump"
 
+    # shellcheck disable=SC2154 # $initdir is a variable from dracut
     chmod -x "${initdir}/$KDUMP_KERNEL"
 }

--- a/dracut-early-kdump.sh
+++ b/dracut-early-kdump.sh
@@ -6,7 +6,6 @@ standard_kexec_args="-p"
 EARLY_KDUMP_INITRD=""
 EARLY_KDUMP_KERNEL=""
 EARLY_KDUMP_CMDLINE=""
-EARLY_KDUMP_KERNELVER=""
 EARLY_KEXEC_ARGS=""
 
 . /etc/sysconfig/kdump
@@ -57,7 +56,7 @@ early_kdump_load()
 	ddebug "earlykdump: $KEXEC ${EARLY_KEXEC_ARGS} $standard_kexec_args \
 	--command-line=$EARLY_KDUMP_CMDLINE --initrd=$EARLY_KDUMP_INITRD \
 	$EARLY_KDUMP_KERNEL"
-
+	# shellcheck disable=SC2086 # $EARLY_KEXEC_ARGS depends on word splitting
 	if $KEXEC $EARLY_KEXEC_ARGS $standard_kexec_args \
 		--command-line="$EARLY_KDUMP_CMDLINE" \
 		--initrd=$EARLY_KDUMP_INITRD $EARLY_KDUMP_KERNEL; then

--- a/dracut-early-kdump.sh
+++ b/dracut-early-kdump.sh
@@ -16,69 +16,69 @@ EARLY_KEXEC_ARGS=""
 
 # initiate the kdump logger
 if ! dlog_init; then
-        echo "failed to initiate the kdump logger."
-        exit 1
+	echo "failed to initiate the kdump logger."
+	exit 1
 fi
 
 prepare_parameters()
 {
-    EARLY_KDUMP_CMDLINE=$(prepare_cmdline "${KDUMP_COMMANDLINE}" "${KDUMP_COMMANDLINE_REMOVE}" "${KDUMP_COMMANDLINE_APPEND}")
-    EARLY_KDUMP_KERNEL="/boot/kernel-earlykdump"
-    EARLY_KDUMP_INITRD="/boot/initramfs-earlykdump"
+	EARLY_KDUMP_CMDLINE=$(prepare_cmdline "${KDUMP_COMMANDLINE}" "${KDUMP_COMMANDLINE_REMOVE}" "${KDUMP_COMMANDLINE_APPEND}")
+	EARLY_KDUMP_KERNEL="/boot/kernel-earlykdump"
+	EARLY_KDUMP_INITRD="/boot/initramfs-earlykdump"
 }
 
 early_kdump_load()
 {
-    if ! check_kdump_feasibility; then
-        return 1
-    fi
+	if ! check_kdump_feasibility; then
+		return 1
+	fi
 
-    if is_fadump_capable; then
-        dwarn "WARNING: early kdump doesn't support fadump."
-        return 1
-    fi
+	if is_fadump_capable; then
+		dwarn "WARNING: early kdump doesn't support fadump."
+		return 1
+	fi
 
-    if check_current_kdump_status; then
-        return 1
-    fi
+	if check_current_kdump_status; then
+		return 1
+	fi
 
-    prepare_parameters
+	prepare_parameters
 
-    EARLY_KEXEC_ARGS=$(prepare_kexec_args "${KEXEC_ARGS}")
+	EARLY_KEXEC_ARGS=$(prepare_kexec_args "${KEXEC_ARGS}")
 
-    if is_secure_boot_enforced; then
-        dinfo "Secure Boot is enabled. Using kexec file based syscall."
-        EARLY_KEXEC_ARGS="$EARLY_KEXEC_ARGS -s"
-    fi
+	if is_secure_boot_enforced; then
+		dinfo "Secure Boot is enabled. Using kexec file based syscall."
+		EARLY_KEXEC_ARGS="$EARLY_KEXEC_ARGS -s"
+	fi
 
-    # Here, only output the messages, but do not save these messages
-    # to a file because the target disk may not be mounted yet, the
-    # earlykdump is too early.
-    ddebug "earlykdump: $KEXEC ${EARLY_KEXEC_ARGS} $standard_kexec_args \
+	# Here, only output the messages, but do not save these messages
+	# to a file because the target disk may not be mounted yet, the
+	# earlykdump is too early.
+	ddebug "earlykdump: $KEXEC ${EARLY_KEXEC_ARGS} $standard_kexec_args \
 	--command-line=$EARLY_KDUMP_CMDLINE --initrd=$EARLY_KDUMP_INITRD \
 	$EARLY_KDUMP_KERNEL"
 
-    if $KEXEC $EARLY_KEXEC_ARGS $standard_kexec_args \
-        --command-line="$EARLY_KDUMP_CMDLINE" \
-        --initrd=$EARLY_KDUMP_INITRD $EARLY_KDUMP_KERNEL; then
-        dinfo "kexec: loaded early-kdump kernel"
-        return 0
-    else
-        derror "kexec: failed to load early-kdump kernel"
-        return 1
-    fi
+	if $KEXEC $EARLY_KEXEC_ARGS $standard_kexec_args \
+		--command-line="$EARLY_KDUMP_CMDLINE" \
+		--initrd=$EARLY_KDUMP_INITRD $EARLY_KDUMP_KERNEL; then
+		dinfo "kexec: loaded early-kdump kernel"
+		return 0
+	else
+		derror "kexec: failed to load early-kdump kernel"
+		return 1
+	fi
 }
 
 set_early_kdump()
 {
-    if getargbool 0 rd.earlykdump; then
-        dinfo "early-kdump is enabled."
-        early_kdump_load
-    else
-        dinfo "early-kdump is disabled."
-    fi
+	if getargbool 0 rd.earlykdump; then
+		dinfo "early-kdump is enabled."
+		early_kdump_load
+	else
+		dinfo "early-kdump is disabled."
+	fi
 
-    return 0
+	return 0
 }
 
 set_early_kdump

--- a/dracut-fadump-init-fadump.sh
+++ b/dracut-fadump-init-fadump.sh
@@ -37,7 +37,7 @@ if [ -f /proc/device-tree/rtas/ibm,kernel-dump ] || [ -f /proc/device-tree/ibm,o
 				case $mp in
 				/oldroot/*) umount -d "$mp" && loop=1 ;;
 				esac
-			done </proc/mounts
+			done < /proc/mounts
 		done
 		umount -d -l oldroot
 

--- a/kdump-dep-generator.sh
+++ b/kdump-dep-generator.sh
@@ -11,13 +11,13 @@
 dest_dir="/tmp"
 
 if [ -n "$1" ]; then
-    dest_dir=$1
+	dest_dir=$1
 fi
 
 systemd_dir=/usr/lib/systemd/system
 kdump_wants=$dest_dir/kdump.service.wants
 
 if is_ssh_dump_target; then
-    mkdir -p $kdump_wants
-    ln -sf $systemd_dir/network-online.target $kdump_wants/
+	mkdir -p $kdump_wants
+	ln -sf $systemd_dir/network-online.target $kdump_wants/
 fi

--- a/kdump-lib.sh
+++ b/kdump-lib.sh
@@ -451,8 +451,7 @@ is_wdt_active()
 
 have_compression_in_dracut_args()
 {
-	[[ "$(kdump_get_conf_val dracut_args)" =~ \
-		(^|[[:space:]])--(gzip|bzip2|lzma|xz|lzo|lz4|zstd|no-compress|compress)([[:space:]]|$) ]]
+	[[ "$(kdump_get_conf_val dracut_args)" =~ (^|[[:space:]])--(gzip|bzip2|lzma|xz|lzo|lz4|zstd|no-compress|compress)([[:space:]]|$) ]]
 }
 
 # If "dracut_args" contains "--mount" information, use it
@@ -829,7 +828,7 @@ PROC_IOMEM=/proc/iomem
 get_system_size()
 {
 	sum=$(sed -n "s/\s*\([0-9a-fA-F]\+\)-\([0-9a-fA-F]\+\) : System RAM$/+ 0x\2 - 0x\1 + 1/p" $PROC_IOMEM)
-	echo $(( (sum) / 1024 / 1024 / 1024))
+	echo $(((sum) / 1024 / 1024 / 1024))
 }
 
 # Return the recommended size for the reserved crashkernel memory
@@ -927,7 +926,7 @@ get_luks_crypt_dev()
 
 	[[ -b /dev/block/$1 ]] || return 1
 
-	_type=$(blkid -u filesystem,crypto -o export -- "/dev/block/$1" | \
+	_type=$(blkid -u filesystem,crypto -o export -- "/dev/block/$1" |
 		sed -n -E "s/^TYPE=(.*)$/\1/p")
 	[[ $_type == "crypto_LUKS" ]] && echo "$1"
 

--- a/kdump-migrate-action.sh
+++ b/kdump-migrate-action.sh
@@ -2,7 +2,7 @@
 
 systemctl is-active kdump
 if [ $? -ne 0 ]; then
-        exit 0
+	exit 0
 fi
 
 /usr/lib/kdump/kdump-restart.sh

--- a/kdump-restart.sh
+++ b/kdump-restart.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 export PATH="$PATH:/usr/bin:/usr/sbin"
 
-exec >>/var/log/kdump-migration.log 2>&1
+exec >> /var/log/kdump-migration.log 2>&1
 
 echo "kdump: Partition Migration detected. Rebuilding initramfs image to reload."
 /usr/bin/kdumpctl rebuild

--- a/kdumpctl
+++ b/kdumpctl
@@ -720,7 +720,7 @@ check_ssh_config()
 
 	[[ "${OPT[_fstype]}" == ssh ]] || return 0
 
-	target=$(ssh -G "${OPT[_target]}" | sed  -n -e "s/^hostname[[:space:]]\+\([^[:space:]]*\).*$/\1/p")
+	target=$(ssh -G "${OPT[_target]}" | sed -n -e "s/^hostname[[:space:]]\+\([^[:space:]]*\).*$/\1/p")
 	[[ ${OPT[_target]} =~ .*@.* ]] || return 1
 	if [[ ${OPT[_target]#*@} != "$target" ]]; then
 		derror "Invalid ssh destination ${OPT[_target]} provided."
@@ -788,7 +788,7 @@ propagate_ssh_key()
 
 	parse_config || return 1
 
-	if [[ ${OPT[_fstype]} != ssh ]] ; then
+	if [[ ${OPT[_fstype]} != ssh ]]; then
 		derror "No ssh destination defined in $KDUMP_CONFIG_FILE."
 		derror "Please verify that $KDUMP_CONFIG_FILE contains 'ssh <user>@<host>' and that it is properly formatted."
 		exit 1
@@ -1468,30 +1468,30 @@ reset_crashkernel()
 
 	for _opt in "$@"; do
 		case "$_opt" in
-			--fadump=*)
-				_val=${_opt#*=}
-				if _dump_mode=$(get_dump_mode_by_fadump_val $_val); then
-					_fadump_val=$_val
-				else
-					derror "failed to determine dump mode"
-					exit
-				fi
-				;;
-			--kernel=*)
-				_val=${_opt#*=}
-				if ! _valid_grubby_kernel_path $_val; then
-					derror "Invalid $_opt, please specify a valid kernel path, ALL or DEFAULT"
-					exit
-				fi
-				_grubby_kernel_path=$_val
-				;;
-			--reboot)
-				_reboot=yes
-				;;
-			*)
-				derror "$_opt not recognized"
-				exit 1
-				;;
+		--fadump=*)
+			_val=${_opt#*=}
+			if _dump_mode=$(get_dump_mode_by_fadump_val $_val); then
+				_fadump_val=$_val
+			else
+				derror "failed to determine dump mode"
+				exit
+			fi
+			;;
+		--kernel=*)
+			_val=${_opt#*=}
+			if ! _valid_grubby_kernel_path $_val; then
+				derror "Invalid $_opt, please specify a valid kernel path, ALL or DEFAULT"
+				exit
+			fi
+			_grubby_kernel_path=$_val
+			;;
+		--reboot)
+			_reboot=yes
+			;;
+		*)
+			derror "$_opt not recognized"
+			exit 1
+			;;
 		esac
 	done
 
@@ -1550,10 +1550,10 @@ reset_crashkernel()
 	if [[ -z $_grubby_kernel_path ]]; then
 		if [[ -z $KDUMP_KERNELVER ]] ||
 			! _kernel_path=$(_find_kernel_path_by_release "$KDUMP_KERNELVER"); then
-					if ! _kernel_path=$(_get_current_running_kernel_path); then
-						derror "no running kernel found"
-						exit 1
-					fi
+			if ! _kernel_path=$(_get_current_running_kernel_path); then
+				derror "no running kernel found"
+				exit 1
+			fi
 		fi
 		_kernels=$_kernel_path
 	else
@@ -1615,9 +1615,9 @@ update_crashkernel_in_grub_etc_default_after_update()
 	_new_default_crashkernel=${_crashkernel_vals[new_${_dump_mode}]}
 
 	if [[ $_crashkernel == auto ]] ||
-		  [[ $_crashkernel == "$_old_default_crashkernel" &&
-		     $_new_default_crashkernel != "$_old_default_crashkernel" ]]; then
-			_update_kernel_arg_in_grub_etc_default crashkernel "$_new_default_crashkernel"
+		[[ $_crashkernel == "$_old_default_crashkernel" &&
+			$_new_default_crashkernel != "$_old_default_crashkernel" ]]; then
+		_update_kernel_arg_in_grub_etc_default crashkernel "$_new_default_crashkernel"
 	fi
 }
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -42,7 +42,7 @@ all: $(TEST_ROOT)/output/test-base-image
 # to rebuild the rpm, currently use rpmbuild to have better control over the rpm building process
 #
 $(KEXEC_TOOLS_RPM): $(KEXEC_TOOLS_SRC)
-	sh -c "cd .. && fedpkg sources"
+	sh -c "cd .. && fedpkg --release f$(RELEASE) sources"
 	@echo Rebuilding RPM due to modification of sources: $?
 	rpmbuild $(RPMDEFINE) -ba $(REPO)/$(SPEC)
 

--- a/tests/scripts/build-image.sh
+++ b/tests/scripts/build-image.sh
@@ -54,4 +54,10 @@ img_add_qemu_cmd() {
 
 [ -e "$INST_SCRIPT" ] && source $INST_SCRIPT
 
+if [[ $USE_GUESTMOUNT ]]; then
+	# unmount the image before renaming it otherwise sync_guestunmount may falsely
+	# think that the image has been truely unmounted
+	sync_guestunmount $OUTPUT_IMAGE.building ${MNTS[$OUTPUT_IMAGE.building]}
+fi
+
 mv $OUTPUT_IMAGE.building $OUTPUT_IMAGE

--- a/tests/scripts/image-init-lib.sh
+++ b/tests/scripts/image-init-lib.sh
@@ -23,7 +23,7 @@ is_mounted()
 clean_up()
 {
 	for _mnt in ${MNTS[@]}; do
-		is_mounted $_mnt && $SUDO umount -f $_mnt
+		is_mounted $_mnt && $SUDO umount -f -R $_mnt
 	done
 
 	for _dev in ${DEVS[@]}; do
@@ -81,6 +81,21 @@ get_mountable_dev() {
 	fi
 }
 
+# get the separate boot partition
+# return the 2nd partition as boot partition
+get_mount_boot() {
+	local dev=$1 parts
+
+	$SUDO partprobe $dev && sync
+	parts="$(ls -1 ${dev}p*)"
+	if [ -n "$parts" ]; then
+		if [ $(echo "$parts" | wc -l) -gt 1 ]; then
+			echo "$parts" | head -2 | tail -1
+		fi
+	fi
+}
+
+
 prepare_loop() {
 	[ -n "$(lsmod | grep "^loop")" ] && return
 
@@ -133,7 +148,7 @@ image_lock()
 # Mount a device, will umount it automatially when shell exits
 mount_image() {
 	local image=$1 fmt
-	local dev mnt mnt_dev
+	local dev mnt mnt_dev boot root
 
 	# Lock the image just in case user run this script in parrel
 	image_lock $image
@@ -166,12 +181,20 @@ mount_image() {
 
 	$SUDO mount $mnt_dev $mnt
 	[ $? -ne 0 ] && perror_exit "failed to mount device '$mnt_dev'"
+	boot=$(get_mount_boot "$dev")
+	if [[ -n "$boot" ]]; then
+		root=$(get_image_mount_root $image)
+		$SUDO mount $boot $root/boot
+		[ $? -ne 0 ] && perror_exit "failed to mount the bootable partition for device '$mnt_dev'"
+	fi
 }
 
 get_image_mount_root() {
 	local image=$1
 	local root=${MNTS[$image]}
 
+	# Starting from Fedora 36, the root node is /root/root of the last partition
+	[ -d "$root/root/root" ] && root=$root/root
 	echo $root
 
 	if [ -z "$root" ]; then
@@ -213,7 +236,7 @@ run_in_image() {
 
 inst_in_image() {
 	local image=$1 src=$2 dst=$3
-	local root=${MNTS[$image]}
+	local root=$(get_image_mount_root $1)
 
 	$SUDO cp $src $root/$dst
 }

--- a/tests/scripts/image-init-lib.sh
+++ b/tests/scripts/image-init-lib.sh
@@ -263,7 +263,7 @@ create_image_from_base_image() {
 	if [ "$image_fmt" != "raw" ]; then
 		if fmt_is_qcow2 "$image_fmt"; then
 			echo "Source image is qcow2, using snapshot..."
-			qemu-img create -f qcow2 -b $image $output
+			qemu-img create -f qcow2 -b $image -F qcow2 $output
 		else
 			perror_exit "Unrecognized base image format '$image_mnt'"
 		fi

--- a/tests/scripts/image-init-lib.sh
+++ b/tests/scripts/image-init-lib.sh
@@ -20,20 +20,64 @@ is_mounted()
        findmnt -k -n $1 &>/dev/null
 }
 
+is_qemu_image_locked()
+{
+	qemu-img info $1 2>&1 >/dev/null | grep -q "lock"
+}
+
+# call guestmount and wait for image is truely umounted.
+#
+# guestumount simply asks qemu to quit. When guesumount returns, qemu may still
+# in the quiting process. In this case, if we start a new qemu instance, it will
+# complain with 'Failed to get shared "write" lock'.
+sync_guestunmount() {
+	local i _image _mnt _wait_times
+
+	DEFAULT_TIMES=100
+	_image=$1
+	_mnt=$2
+	i=0
+
+	$SUDO LIBGUESTFS_BACKEND=direct guestunmount $_mnt
+
+	if [[ $GUEST_UNMOUNT_WAIT_TIMES ]]; then
+		_wait_times=$GUEST_UNMOUNT_WAIT_TIMES
+	else
+		_wait_times=$DEFAULT_TIMES
+	fi
+
+	# wait 10s at maximum for $_image to be available
+	while is_qemu_image_locked $_image && [[ $i -lt $_wait_times ]]; do
+		i=$[$i+1]
+		sleep 0.1
+	done
+
+	if [[ $i == $_wait_times ]]; then
+		perror_exit "After 0.1*$_wait_times seconds, $_image is still locked. You may need to increase GUEST_UNMOUNT_WAIT_TIMES (default=$DEFAULT_TIMES)"
+	fi
+}
+
 clean_up()
 {
-	for _mnt in ${MNTS[@]}; do
-		is_mounted $_mnt && $SUDO umount -f -R $_mnt
+	for _image in ${!MNTS[@]}; do
+		_mnt=${MNTS[$_image]}
+		if [[ $USE_GUESTMOUNT ]] && is_mounted $_mnt; then
+			sync_guestunmount $_image $_mnt
+		else
+			is_mounted $_mnt && $SUDO umount -f -R $_mnt
+		fi
+		rm $_image.lock
 	done
 
-	for _dev in ${DEVS[@]}; do
-		[ ! -e "$_dev" ] && continue
-		[[ "$_dev" == "/dev/loop"* ]] && $SUDO losetup -d "$_dev"
-		[[ "$_dev" == "/dev/nbd"* ]] && $SUDO qemu-nbd --disconnect "$_dev"
-	done
+	if [[ ! $USE_GUESTMOUNT ]]; then
+		for _dev in ${DEVS[@]}; do
+			[ ! -e "$_dev" ] && continue
+			[[ "$_dev" == "/dev/loop"* ]] && $SUDO losetup -d "$_dev"
+			[[ "$_dev" == "/dev/nbd"* ]] && $SUDO qemu-nbd --disconnect "$_dev"
+		done
+	fi
 
 	[ -d "$TMPDIR" ] && $SUDO rm --one-file-system -rf -- "$TMPDIR";
-
 	sync
 }
 
@@ -163,10 +207,11 @@ mount_image() {
 		[ $? -ne 0 ] || [ -z "$dev" ] && perror_exit "failed to setup loop device"
 
 	elif fmt_is_qcow2 "$fmt"; then
-		prepare_nbd
-
-		dev=$(mount_nbd $image)
-		[ $? -ne 0 ] || [ -z "$dev" ] perror_exit "failed to connect qemu to nbd device '$dev'"
+		if [[ ! $USE_GUESTMOUNT ]]; then
+			prepare_nbd
+			dev=$(mount_nbd $image)
+			[ $? -ne 0 ] || [ -z "$dev" ] perror_exit "failed to connect qemu to nbd device '$dev'"
+		fi
 	else
 		perror_exit "Unrecognized image format '$fmt'"
 	fi
@@ -176,16 +221,19 @@ mount_image() {
 	[ $? -ne 0 ] || [ -z "$mnt" ] && perror_exit "failed to create tmp mount dir"
 	MNTS[$image]="$mnt"
 
-	mnt_dev=$(get_mountable_dev "$dev")
-	[ $? -ne 0 ] || [ -z "$mnt_dev" ] && perror_exit "failed to setup loop device"
-
-	$SUDO mount $mnt_dev $mnt
-	[ $? -ne 0 ] && perror_exit "failed to mount device '$mnt_dev'"
-	boot=$(get_mount_boot "$dev")
-	if [[ -n "$boot" ]]; then
-		root=$(get_image_mount_root $image)
-		$SUDO mount $boot $root/boot
-		[ $? -ne 0 ] && perror_exit "failed to mount the bootable partition for device '$mnt_dev'"
+	if [[ $USE_GUESTMOUNT ]]; then
+		$SUDO LIBGUESTFS_BACKEND=direct guestmount -a $image -i $mnt
+	else
+		mnt_dev=$(get_mountable_dev "$dev")
+		[ $? -ne 0 ] || [ -z "$mnt_dev" ] && perror_exit "failed to setup loop device"
+		$SUDO mount $mnt_dev $mnt
+		[ $? -ne 0 ] && perror_exit "failed to mount device '$mnt_dev'"
+		boot=$(get_mount_boot "$dev")
+		if [[ -n "$boot" ]]; then
+			root=$(get_image_mount_root $image)
+			$SUDO mount $boot $root/boot
+			[ $? -ne 0 ] && perror_exit "failed to mount the bootable partition for device '$mnt_dev'"
+		fi
 	fi
 }
 
@@ -222,7 +270,7 @@ inst_pkg_in_image() {
 	# if [ "$distro" != "Fedora" ]; then
 	# 	perror_exit "only Fedora image is supported"
 	# fi
-	release=$(cat $root/etc/fedora-release | sed -n "s/.*[Rr]elease\s*\([0-9]*\).*/\1/p")
+	release=$(sudo cat $root/etc/fedora-release | sed -n "s/.*[Rr]elease\s*\([0-9]*\).*/\1/p")
 	[ $? -ne 0 ] || [ -z "$release" ] && perror_exit "only Fedora image is supported"
 
 	$SUDO dnf --releasever=$release --installroot=$root install -y $@

--- a/tests/scripts/test-lib.sh
+++ b/tests/scripts/test-lib.sh
@@ -86,10 +86,16 @@ build_test_image() {
 }
 
 run_test_sync() {
-	local qemu_cmd=$(get_test_qemu_cmd $1)
+	local qemu_cmd=$(get_test_qemu_cmd $1) _timeout
+
+	if [[ $KUMP_TEST_QEMU_TIMEOUT ]]; then
+		_timeout=$KUMP_TEST_QEMU_TIMEOUT
+	else
+		_timeout=10m
+	fi
 
 	if [ -n "$qemu_cmd" ]; then
-		timeout --foreground 10m $BASEDIR/run-qemu $(get_test_qemu_cmd $1)
+		timeout --foreground $_timeout $BASEDIR/run-qemu $(get_test_qemu_cmd $1)
 	else
 		echo "error: test qemu command line is not configured" > /dev/stderr
 		return 1

--- a/tools/run-integration-tests.sh
+++ b/tools/run-integration-tests.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -ex
+
+[[ -d ${0%/*} ]] && cd "${0%/*}"/../
+
+source /etc/os-release
+
+cd tests
+
+# fedpkg fetch sources based on branch.f$VERSION_ID.remote
+if ! git remote show | grep -q fedora_src; then
+	git remote add fedora_src https://src.fedoraproject.org/rpms/kexec-tools.git
+	git config --add branch.f$VERSION_ID.remote fedora_src
+fi
+
+can_we_use_qemu_nbd()
+{
+	_tmp_img=/tmp/test.qcow2
+
+	(sudo -v && sudo modprobe nbd \
+		&& qemu-img create -fqcow2 $_tmp_img 10m \
+		&& qemu-nbd -c /dev/nbd0 $_tmp_img && sudo qemu-nbd -d /dev/nbd0 && rm $_tmp_img) &> /dev/null
+}
+
+if ! can_we_use_qemu_nbd; then
+	USE_GUESTMOUNT=1
+fi
+
+KUMP_TEST_QEMU_TIMEOUT=20m USE_GUESTMOUNT=$USE_GUESTMOUNT BASE_IMAGE=/usr/share/cloud_images/Fedora-Cloud-Base-35-1.2.x86_64.qcow2 RELEASE=$VERSION_ID make test-run


### PR DESCRIPTION
Resolves: bz2092012

According to the ostree team [1], the existence of /run/ostree-booted
> is the most stable way to signal/check that a system has been
> booted in ostree-style.  It is also used by rpm-ostree at
> compose/install time in the sandboxed environment where scriptlets run,
> in order to signal that the package is being installed/composed into
> an ostree commit (i.e. not directly on a live system).  See
> https://github.com/coreos/rpm-ostree/blob/8ddf5f40d9cbbd9d3668cc75b703316e0a89ab11/src/libpriv/rpmostree-scripts.cxx#L350-L353
> for reference.

By checking the existence of /run/ostree-booted, we could skip trying to
update kernel cmdline during OSTree compose time.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=2092012#c3

Reported-by: Luca BRUNO <lucab@redhat.com>
Suggested-by: Luca BRUNO <lucab@redhat.com>
Fixes: 0adb0f4 ("try to reset kernel crashkernel when kexec-tools updates the default crashkernel value")
Signed-off-by: Coiby Xu <coxu@redhat.com>
Reviewed-by: Philipp Rudo <prudo@redhat.com>
Acked-by: Timothée Ravier <siosm@fedoraproject.org>