### PR TITLE
reuse NetworkManager connection profiles to set up kdump network

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,53 @@
+name: kexec-tools tests
+
+on: pull_request
+
+jobs:
+  format-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: wget https://github.com/mvdan/sh/releases/download/v3.4.3/shfmt_v3.4.3_linux_amd64 -O /usr/local/bin/shfmt && chmod +x /usr/local/bin/shfmt
+      - run: shfmt -d *.sh kdumpctl mk*dumprd
+
+  static-analysis:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: curl -L -O https://github.com/koalaman/shellcheck/releases/download/v0.8.0/shellcheck-v0.8.0.linux.x86_64.tar.xz && tar -xJf shellcheck-v0.8.0.linux.x86_64.tar.xz
+      # Currently, for kexec-tools, there is need for shellcheck to require
+      # the sourced file to give correct warnings about the checked file
+      - run: shellcheck-v0.8.0/shellcheck --exclude=1090,1091 *.sh spec/*.sh kdumpctl mk*dumprd
+
+  unit-tests:
+    runs-on: ubuntu-latest
+    container: docker.io/fedora:latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: sudo dnf install -y make dracut grubby hostname
+      - run: curl -L -O https://github.com/shellspec/shellspec/archive/latest.tar.gz && tar -xzf latest.tar.gz
+      - run: cd shellspec-latest && sudo make install
+      - run: shellspec
+
+  integration-tests:
+        runs-on: self-hosted
+        timeout-minutes: 45
+        concurrency:
+            group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}
+            cancel-in-progress: true
+        strategy:
+            matrix:
+                container: [
+                        "fedora:36",
+                ]
+            fail-fast: false
+        container:
+            image: ghcr.io/coiby/${{ matrix.container }}
+            options: "--privileged -v /dev:/dev -v /lib/modules:/lib/modules:ro"
+        steps:
+            -   name: "Checkout Repository"
+                uses: actions/checkout@v2
+                with:
+                    fetch-depth: 0
+            -   name: "${{ matrix.container }} kdump tests"
+                run: bash ./tools/run-integration-tests.sh

--- a/dracut-early-kdump-module-setup.sh
+++ b/dracut-early-kdump-module-setup.sh
@@ -23,7 +23,7 @@ prepare_kernel_initrd() {
 
     prepare_kdump_bootinfo
 
-    # $kernel is a variable from dracut
+    # shellcheck disable=SC2154 # $kernel is a variable from dracut
     if [[ $KDUMP_KERNELVER != "$kernel" ]]; then
         dwarn "Using kernel version '$KDUMP_KERNELVER' for early kdump," \
             "but the initramfs is generated for kernel version '$kernel'"
@@ -54,6 +54,7 @@ install() {
     inst_script "/lib/kdump/kdump-lib.sh" "/lib/kdump-lib.sh"
     inst_script "/lib/kdump/kdump-lib-initramfs.sh" "/lib/kdump/kdump-lib-initramfs.sh"
     inst_script "/lib/kdump/kdump-logger.sh" "/lib/kdump-logger.sh"
+    # shellcheck disable=SC2154 # $moddir is a variable from dracut
     inst_hook cmdline 00 "$moddir/early-kdump.sh"
     inst_binary "$KDUMP_KERNEL"
     inst_binary "$KDUMP_INITRD"
@@ -61,5 +62,6 @@ install() {
     ln_r "$KDUMP_KERNEL" "/boot/kernel-earlykdump"
     ln_r "$KDUMP_INITRD" "/boot/initramfs-earlykdump"
 
+    # shellcheck disable=SC2154 # $initdir is a variable from dracut
     chmod -x "${initdir}/$KDUMP_KERNEL"
 }

--- a/dracut-early-kdump.sh
+++ b/dracut-early-kdump.sh
@@ -6,7 +6,6 @@ standard_kexec_args="-p"
 EARLY_KDUMP_INITRD=""
 EARLY_KDUMP_KERNEL=""
 EARLY_KDUMP_CMDLINE=""
-EARLY_KDUMP_KERNELVER=""
 EARLY_KEXEC_ARGS=""
 
 . /etc/sysconfig/kdump
@@ -57,7 +56,7 @@ early_kdump_load()
 	ddebug "earlykdump: $KEXEC ${EARLY_KEXEC_ARGS} $standard_kexec_args \
 	--command-line=$EARLY_KDUMP_CMDLINE --initrd=$EARLY_KDUMP_INITRD \
 	$EARLY_KDUMP_KERNEL"
-
+	# shellcheck disable=SC2086 # $EARLY_KEXEC_ARGS depends on word splitting
 	if $KEXEC $EARLY_KEXEC_ARGS $standard_kexec_args \
 		--command-line="$EARLY_KDUMP_CMDLINE" \
 		--initrd=$EARLY_KDUMP_INITRD $EARLY_KDUMP_KERNEL; then

--- a/dracut-early-kdump.sh
+++ b/dracut-early-kdump.sh
@@ -16,69 +16,69 @@ EARLY_KEXEC_ARGS=""
 
 # initiate the kdump logger
 if ! dlog_init; then
-        echo "failed to initiate the kdump logger."
-        exit 1
+	echo "failed to initiate the kdump logger."
+	exit 1
 fi
 
 prepare_parameters()
 {
-    EARLY_KDUMP_CMDLINE=$(prepare_cmdline "${KDUMP_COMMANDLINE}" "${KDUMP_COMMANDLINE_REMOVE}" "${KDUMP_COMMANDLINE_APPEND}")
-    EARLY_KDUMP_KERNEL="/boot/kernel-earlykdump"
-    EARLY_KDUMP_INITRD="/boot/initramfs-earlykdump"
+	EARLY_KDUMP_CMDLINE=$(prepare_cmdline "${KDUMP_COMMANDLINE}" "${KDUMP_COMMANDLINE_REMOVE}" "${KDUMP_COMMANDLINE_APPEND}")
+	EARLY_KDUMP_KERNEL="/boot/kernel-earlykdump"
+	EARLY_KDUMP_INITRD="/boot/initramfs-earlykdump"
 }
 
 early_kdump_load()
 {
-    if ! check_kdump_feasibility; then
-        return 1
-    fi
+	if ! check_kdump_feasibility; then
+		return 1
+	fi
 
-    if is_fadump_capable; then
-        dwarn "WARNING: early kdump doesn't support fadump."
-        return 1
-    fi
+	if is_fadump_capable; then
+		dwarn "WARNING: early kdump doesn't support fadump."
+		return 1
+	fi
 
-    if check_current_kdump_status; then
-        return 1
-    fi
+	if check_current_kdump_status; then
+		return 1
+	fi
 
-    prepare_parameters
+	prepare_parameters
 
-    EARLY_KEXEC_ARGS=$(prepare_kexec_args "${KEXEC_ARGS}")
+	EARLY_KEXEC_ARGS=$(prepare_kexec_args "${KEXEC_ARGS}")
 
-    if is_secure_boot_enforced; then
-        dinfo "Secure Boot is enabled. Using kexec file based syscall."
-        EARLY_KEXEC_ARGS="$EARLY_KEXEC_ARGS -s"
-    fi
+	if is_secure_boot_enforced; then
+		dinfo "Secure Boot is enabled. Using kexec file based syscall."
+		EARLY_KEXEC_ARGS="$EARLY_KEXEC_ARGS -s"
+	fi
 
-    # Here, only output the messages, but do not save these messages
-    # to a file because the target disk may not be mounted yet, the
-    # earlykdump is too early.
-    ddebug "earlykdump: $KEXEC ${EARLY_KEXEC_ARGS} $standard_kexec_args \
+	# Here, only output the messages, but do not save these messages
+	# to a file because the target disk may not be mounted yet, the
+	# earlykdump is too early.
+	ddebug "earlykdump: $KEXEC ${EARLY_KEXEC_ARGS} $standard_kexec_args \
 	--command-line=$EARLY_KDUMP_CMDLINE --initrd=$EARLY_KDUMP_INITRD \
 	$EARLY_KDUMP_KERNEL"
 
-    if $KEXEC $EARLY_KEXEC_ARGS $standard_kexec_args \
-        --command-line="$EARLY_KDUMP_CMDLINE" \
-        --initrd=$EARLY_KDUMP_INITRD $EARLY_KDUMP_KERNEL; then
-        dinfo "kexec: loaded early-kdump kernel"
-        return 0
-    else
-        derror "kexec: failed to load early-kdump kernel"
-        return 1
-    fi
+	if $KEXEC $EARLY_KEXEC_ARGS $standard_kexec_args \
+		--command-line="$EARLY_KDUMP_CMDLINE" \
+		--initrd=$EARLY_KDUMP_INITRD $EARLY_KDUMP_KERNEL; then
+		dinfo "kexec: loaded early-kdump kernel"
+		return 0
+	else
+		derror "kexec: failed to load early-kdump kernel"
+		return 1
+	fi
 }
 
 set_early_kdump()
 {
-    if getargbool 0 rd.earlykdump; then
-        dinfo "early-kdump is enabled."
-        early_kdump_load
-    else
-        dinfo "early-kdump is disabled."
-    fi
+	if getargbool 0 rd.earlykdump; then
+		dinfo "early-kdump is enabled."
+		early_kdump_load
+	else
+		dinfo "early-kdump is disabled."
+	fi
 
-    return 0
+	return 0
 }
 
 set_early_kdump

--- a/dracut-fadump-init-fadump.sh
+++ b/dracut-fadump-init-fadump.sh
@@ -37,7 +37,7 @@ if [ -f /proc/device-tree/rtas/ibm,kernel-dump ] || [ -f /proc/device-tree/ibm,o
 				case $mp in
 				/oldroot/*) umount -d "$mp" && loop=1 ;;
 				esac
-			done </proc/mounts
+			done < /proc/mounts
 		done
 		umount -d -l oldroot
 

--- a/dracut-fadump-init-fadump.sh
+++ b/dracut-fadump-init-fadump.sh
@@ -15,9 +15,7 @@ if [ -f /proc/device-tree/rtas/ibm,kernel-dump ] || [ -f /proc/device-tree/ibm,o
 	mount -t ramfs ramfs /newroot
 
 	if [ $ROOTFS_IS_RAMFS ]; then
-		for FILE in $(ls -A /fadumproot/); do
-			mv /fadumproot/$FILE /newroot/
-		done
+		find /fadumproot/ -mindepth 1 -maxdepth 1 -exec mv {} /newroot/ \;
 		exec switch_root /newroot /init
 	else
 		mkdir /newroot/sys /newroot/proc /newroot/dev /newroot/run /newroot/oldroot

--- a/dracut-fadump-module-setup.sh
+++ b/dracut-fadump-module-setup.sh
@@ -9,7 +9,9 @@ depends() {
 }
 
 install() {
+    # shellcheck disable=SC2154 # $initdir is a dracut variable
     mv -f "$initdir/init" "$initdir/init.dracut"
+    # shellcheck disable=SC2154 # $moddir is a dracut variable
     inst_script "$moddir/init-fadump.sh" /init
     chmod a+x "$initdir/init"
 

--- a/dracut-kdump.sh
+++ b/dracut-kdump.sh
@@ -491,25 +491,28 @@ save_vmcore_dmesg_ssh()
 
 get_host_ip()
 {
-	if is_nfs_dump_target || is_ssh_dump_target; then
-		kdumpnic=$(getarg kdumpnic=)
-		if [ -z "$kdumpnic" ]; then
-			derror "failed to get kdumpnic!"
-			return 1
-		fi
-		if ! kdumphost=$(ip addr show dev "$kdumpnic" | grep '[ ]*inet'); then
-			derror "wrong kdumpnic: $kdumpnic"
-			return 1
-		fi
-		kdumphost=$(echo "$kdumphost" | head -n 1 | awk '{print $2}')
-		kdumphost="${kdumphost%%/*}"
-		if [ -z "$kdumphost" ]; then
-			derror "wrong kdumpnic: $kdumpnic"
-			return 1
-		fi
-		HOST_IP=$kdumphost
+
+	if ! is_nfs_dump_target && ! is_ssh_dump_target; then
+		return 0
 	fi
-	return 0
+
+	_kdump_remote_ip=$(getarg kdump_remote_ip=)
+
+	if [ -z "$_kdump_remote_ip" ]; then
+		derror "failed to get remote IP address!"
+		return 1
+	fi
+	_route=$(kdump_get_ip_route "$_kdump_remote_ip")
+	_netdev=$(kdump_get_ip_route_field "$_route" "dev")
+
+	if ! _kdumpip=$(ip addr show dev "$_netdev" | grep '[ ]*inet'); then
+		derror "Failed to get IP of $_netdev"
+		return 1
+	fi
+
+	_kdumpip=$(echo "$_kdumpip" | head -n 1 | awk '{print $2}')
+	_kdumpip="${_kdumpip%%/*}"
+	HOST_IP=$_kdumpip
 }
 
 read_kdump_confs()

--- a/dracut-kdump.sh
+++ b/dracut-kdump.sh
@@ -422,14 +422,14 @@ dump_ssh()
 		_ret=$?
 		_vmcore="vmcore"
 	else
-		# shellcheck disable=SC2086 # need to word-split $_ssh_opts
+		# shellcheck disable=SC2086,SC2029 # need to word-split $_ssh_opts and expand $_ssh_dir
 		$CORE_COLLECTOR /proc/vmcore | ssh $_ssh_opts "$2" "umask 0077 && dd bs=512 of='$_ssh_dir/vmcore-incomplete'"
 		_ret=$?
 		_vmcore="vmcore.flat"
 	fi
 
 	if [ $_ret -eq 0 ]; then
-		# shellcheck disable=SC2086 # need to word-split $_ssh_opts
+		# shellcheck disable=SC2086,SC2029 # need to word-split $_ssh_opts and expand $_ssh_dir
 		ssh $_ssh_opts "$2" "mv '$_ssh_dir/vmcore-incomplete' '$_ssh_dir/$_vmcore'"
 		_ret=$?
 		if [ $_ret -ne 0 ]; then
@@ -467,7 +467,7 @@ save_opalcore_ssh()
 		return 1
 	fi
 
-	# shellcheck disable=SC2086 # need to word-split $2
+	# shellcheck disable=SC2086,SC2029 # need to word-split $1 and expand $2
 	ssh $2 "$3" mv "$1/opalcore-incomplete" "$1/opalcore"
 	dinfo "saving opalcore complete"
 	return 0
@@ -480,7 +480,7 @@ save_opalcore_ssh()
 save_vmcore_dmesg_ssh()
 {
 	dinfo "saving vmcore-dmesg.txt to $4:$2"
-	# shellcheck disable=SC2086 # need to word-split $3
+	# shellcheck disable=SC2086,SC2029 # need to word-split $3 and expand $2
 	if $1 /proc/vmcore | ssh $3 "$4" "umask 0077 && dd of='$2/vmcore-dmesg-incomplete.txt'"; then
 		ssh -q $3 "$4" mv "$2/vmcore-dmesg-incomplete.txt" "$2/vmcore-dmesg.txt"
 		dinfo "saving vmcore-dmesg.txt complete"

--- a/dracut-kdump.sh
+++ b/dracut-kdump.sh
@@ -489,6 +489,26 @@ save_vmcore_dmesg_ssh()
 	fi
 }
 
+wait_online_network()
+{
+	# In some cases, network may still not be ready because nm-online is called
+	# with "-s" which means to wait for NetworkManager startup to complete, rather
+	# than waiting for network connectivity specifically. Wait 10mins more for the
+	# network to be truely ready in these cases.
+	_loop=0
+	while [ $_loop -lt 600 ]; do
+		sleep 1
+		_loop=$((_loop + 1))
+		if _route=$(kdump_get_ip_route "$1" 2> /dev/null); then
+			printf "%s" "$_route"
+			return
+		fi
+	done
+
+	derror "Oops. The network still isn't ready after waiting 10mins."
+	exit 1
+}
+
 get_host_ip()
 {
 
@@ -502,7 +522,11 @@ get_host_ip()
 		derror "failed to get remote IP address!"
 		return 1
 	fi
-	_route=$(kdump_get_ip_route "$_kdump_remote_ip")
+
+	if ! _route=$(wait_online_network "$_kdump_remote_ip"); then
+		return 1
+	fi
+
 	_netdev=$(kdump_get_ip_route_field "$_route" "dev")
 
 	if ! _kdumpip=$(ip addr show dev "$_netdev" | grep '[ ]*inet'); then

--- a/dracut-module-setup.sh
+++ b/dracut-module-setup.sh
@@ -470,62 +470,48 @@ kdump_setup_vlan() {
     _save_kdump_netifs "$_parent_netif"
 }
 
-# find online znet device
-# return ifname (_netdev)
-# code reaped from the list_configured function of
-# https://github.com/hreinecke/s390-tools/blob/master/zconf/znetconf
-find_online_znet_device() {
-    local CCWGROUPBUS_DEVICEDIR="/sys/bus/ccwgroup/devices"
-    local NETWORK_DEVICES d ifname ONLINE
-
-    [[ ! -d $CCWGROUPBUS_DEVICEDIR ]] && return
-    NETWORK_DEVICES=$(find $CCWGROUPBUS_DEVICEDIR)
-    for d in $NETWORK_DEVICES; do
-        [[ ! -f "$d/online" ]] && continue
-        read -r ONLINE < "$d/online"
-        if [[ $ONLINE -ne 1 ]]; then
-            continue
-        fi
-        # determine interface name, if there (only for qeth and if
-        # device is online)
-        if [[ -f $d/if_name ]]; then
-            read -r ifname < "$d/if_name"
-        elif [[ -d $d/net ]]; then
-            ifname=$(ls "$d/net/")
-        fi
-        [[ -n $ifname ]] && break
-    done
-    echo -n "$ifname"
+_find_znet_nmconnection() {
+    LANG=C grep -s -E -i -l \
+        "^s390-subchannels=([0-9]\.[0-9]\.[a-f0-9]+;){0,2}" \
+        "$1"/*.nmconnection | LC_ALL=C sed -e "$2"
 }
 
-# setup s390 znet cmdline
-# $1: netdev (ifname)
-# $2: nmcli connection path
+# setup s390 znet
+#
+# Note part of code is extracted from ccw_init provided by s390utils
 kdump_setup_znet() {
-    local _netdev="$1"
-    local _conpath="$2"
-    local s390_prefix="802-3-ethernet.s390-"
-    local _options=""
-    local NETTYPE
-    local SUBCHANNELS
+    local _config_file _unique_name _NM_conf_dir
+    local __sed_discard_ignored_files='/\(~\|\.bak\|\.old\|\.orig\|\.rpmnew\|\.rpmorig\|\.rpmsave\)$/d'
 
-    NETTYPE=$(get_nmcli_field_by_conpath "${s390_prefix}nettype" "$_conpath")
-    SUBCHANNELS=$(get_nmcli_field_by_conpath "${s390_prefix}subchannels" "$_conpath")
-    _options=$(get_nmcli_field_by_conpath "${s390_prefix}options" "$_conpath")
-
-    if [[ -z $NETTYPE || -z $SUBCHANNELS || -z $_options ]]; then
-        dwarning "Failed to get znet configuration via nmlci output. Now try sourcing ifcfg script."
-        source_ifcfg_file "$_netdev"
-        for i in $OPTIONS; do
-            _options=${_options},$i
-        done
+    if [[ "$(uname -m)" != "s390x" ]]; then
+        return
     fi
 
-    if [[ -z $NETTYPE || -z $SUBCHANNELS || -z $_options ]]; then
-        exit 1
+    _NM_conf_dir="/etc/NetworkManager/system-connections"
+
+    _config_file=$(_find_znet_nmconnection "$initdir/$_NM_conf_dir" "$__sed_discard_ignored_files")
+    if [[ -n "$_config_file" ]]; then
+        ddebug "$_config_file has already contained the znet config"
+        return
     fi
 
-    echo "rd.znet=${NETTYPE},${SUBCHANNELS},${_options} rd.znet_ifname=$_netdev:${SUBCHANNELS}" > "${initdir}/etc/cmdline.d/30znet.conf"
+    _config_file=$(LANG=C grep -s -E -i -l \
+        "^[[:space:]]*SUBCHANNELS=['\"]?([0-9]\.[0-9]\.[a-f0-9]+,){0,2}" \
+        /etc/sysconfig/network-scripts/ifcfg-* \
+        | LC_ALL=C sed -e "$__sed_discard_ignored_files")
+
+    if [[ -z "$_config_file" ]]; then
+        _config_file=$(_find_znet_nmconnection "$_NM_conf_dir" "$__sed_discard_ignored_files")
+    fi
+
+    if [[ -n "$_config_file" ]]; then
+        _unique_name=$(cat /proc/sys/kernel/random/uuid)
+        nmcli connection clone --temporary "$_config_file" "$_unique_name" &> >(ddebug)
+        nmcli connection modify --temporary "$_unique_name" connection.autoconnect false
+        inst "/run/NetworkManager/system-connections/${_unique_name}.nmconnection" "${_NM_conf_dir}/${_unique_name}.nmconnection"
+        nmcli connection del "$_unique_name" &> >(ddebug)
+    fi
+
 }
 
 kdump_get_remote_ip() {
@@ -545,21 +531,11 @@ kdump_get_remote_ip() {
 # $1: destination host
 kdump_collect_netif_usage() {
     local _destaddr _srcaddr _route _netdev
-    local _znet_netdev _znet_conpath
 
     _destaddr=$(kdump_get_remote_ip "$1")
     _route=$(kdump_get_ip_route "$_destaddr")
     _srcaddr=$(kdump_get_ip_route_field "$_route" "src")
     _netdev=$(kdump_get_ip_route_field "$_route" "dev")
-
-    _znet_netdev=$(find_online_znet_device)
-    if [[ -n $_znet_netdev ]]; then
-        _znet_conpath=$(get_nmcli_connection_apath_by_ifname "$_znet_netdev")
-        if ! (kdump_setup_znet "$_znet_netdev" "$_znet_conpath"); then
-            derror "Failed to set up znet"
-            exit 1
-        fi
-    fi
 
     if kdump_is_bridge "$_netdev"; then
         kdump_setup_bridge "$_netdev"
@@ -597,6 +573,7 @@ kdump_install_net() {
     if [[ -n "$_netifs" ]]; then
         kdump_install_nmconnections
         apply_nm_initrd_generator_timeouts
+        kdump_setup_znet
         kdump_install_nm_netif_allowlist "$_netifs"
         kdump_install_nic_driver "$_netifs"
     fi

--- a/dracut-module-setup.sh
+++ b/dracut-module-setup.sh
@@ -1,10 +1,21 @@
 #!/bin/bash
 
+_DRACUT_KDUMP_NM_TMP_DIR="/tmp/$$-DRACUT_KDUMP_NM"
+
+cleanup() {
+    rm -rf "$_DRACUT_KDUMP_NM_TMP_DIR"
+}
+
+# shellcheck disable=SC2154 # known issue of shellcheck https://github.com/koalaman/shellcheck/issues/1299
+trap 'ret=$?; cleanup; exit $ret;' EXIT
+
 kdump_module_init() {
     # shellcheck disable=SC2154 # $initdir is a dracut variable
     if ! [[ -d "${initdir}/tmp" ]]; then
         mkdir -p "${initdir}/tmp"
     fi
+
+    mkdir -p "$_DRACUT_KDUMP_NM_TMP_DIR"
 
     . /lib/kdump/kdump-lib.sh
 }
@@ -355,6 +366,71 @@ kdump_setup_ifname() {
     fi
 
     echo "$_ifname"
+}
+
+_clone_nmconnection() {
+    local _clone_output _name _unique_id
+
+    _unique_id=$1
+    _name=$(nmcli --get-values connection.id connection show "$_unique_id")
+    if _clone_output=$(nmcli connection clone --temporary uuid "$_unique_id" "$_name"); then
+        sed -E -n "s/.* \(.*\) cloned as.*\((.*)\)\.$/\1/p" <<< "$_clone_output"
+        return 0
+    fi
+
+    return 1
+}
+
+# Clone and modify NM connection profiles
+#
+# This function makes use of "nmcli clone" to automatically convert ifcfg-*
+# files to Networkmanager .nmconnection connection profiles and also modify the
+# properties of .nmconnection if necessary.
+clone_and_modify_nmconnection() {
+    local _dev _cloned_nmconnection_file_path _tmp_nmconnection_file_path _old_uuid _uuid
+
+    _dev=$1
+    _nmconnection_file_path=$2
+
+    _old_uuid=$(nmcli --get-values connection.uuid connection show filename "$_nmconnection_file_path")
+
+    if ! _uuid=$(_clone_nmconnection "$_old_uuid"); then
+        derror "Failed to clone $_old_uuid"
+        exit 1
+    fi
+
+    _cloned_nmconnection_file_path=$(nmcli --get-values UUID,FILENAME connection show | sed -n "s/^${_uuid}://p")
+    _tmp_nmconnection_file_path=$_DRACUT_KDUMP_NM_TMP_DIR/$(basename "$_nmconnection_file_path")
+    cp "$_cloned_nmconnection_file_path" "$_tmp_nmconnection_file_path"
+    # change uuid back to old value in case it's refered by other connection
+    # profile e.g. connection.master could be interface name of the master
+    # device or UUID of the master connection.
+    sed -i -E "s/(^uuid=).*$/\1${_old_uuid}/g" "$_tmp_nmconnection_file_path"
+    nmcli connection del "$_uuid" &> >(ddebug)
+    echo -n "$_tmp_nmconnection_file_path"
+}
+
+_install_nmconnection() {
+    local _src _nmconnection_name _dst
+
+    _src=$1
+    _nmconnection_name=$(basename "$_src")
+    _dst="/etc/NetworkManager/system-connections/$_nmconnection_name"
+    inst "$_src" "$_dst"
+}
+
+kdump_install_nmconnections() {
+    local _netif _nm_conn_path _cloned_nm_path
+
+    while IFS=: read -r _netif _nm_conn_path; do
+        [[ -v "unique_netifs[$_netif]" ]] || continue
+        if _cloned_nm_path=$(clone_and_modify_nmconnection "$_netif" "$_nm_conn_path"); then
+            _install_nmconnection "$_cloned_nm_path"
+        else
+            derror "Failed to install the .nmconnection for $_netif"
+            exit 1
+        fi
+    done <<< "$(nmcli -t -f device,filename connection show --active)"
 }
 
 kdump_setup_bridge() {
@@ -1036,6 +1112,7 @@ remove_cpu_online_rule() {
 }
 
 install() {
+    declare -A unique_netifs
     local arch
 
     kdump_module_init

--- a/dracut-module-setup.sh
+++ b/dracut-module-setup.sh
@@ -240,26 +240,6 @@ kdump_get_perm_addr() {
     fi
 }
 
-# Prefix kernel assigned names with "kdump-". EX: eth0 -> kdump-eth0
-# Because kernel assigned names are not persistent between 1st and 2nd
-# kernel. We could probably end up with eth0 being eth1, eth0 being
-# eth1, and naming conflict happens.
-kdump_setup_ifname() {
-    local _ifname
-
-    # If ifname already has 'kdump-' prefix, we must be switching from
-    # fadump to kdump. Skip prefixing 'kdump-' in this case as adding
-    # another prefix may truncate the ifname. Since an ifname with
-    # 'kdump-' is already persistent, this should be fine.
-    if [[ $1 =~ eth* ]] && [[ ! $1 =~ ^kdump-* ]]; then
-        _ifname="kdump-$1"
-    else
-        _ifname="$1"
-    fi
-
-    echo "$_ifname"
-}
-
 apply_nm_initrd_generator_timeouts() {
     local _timeout_conf
 
@@ -307,6 +287,19 @@ _clone_nmconnection() {
     return 1
 }
 
+_match_nmconnection_by_mac() {
+    local _unique_id _dev _mac _mac_field
+
+    _unique_id=$1
+    _dev=$2
+
+    _mac=$(kdump_get_perm_addr "$_dev")
+    [[ $_mac != 'not set' ]] || return
+    _mac_field=$(nmcli --get-values connection.type connection show "$_unique_id").mac-address
+    nmcli connection modify --temporary "$_unique_id" "$_mac_field" "$_mac" &> >(ddebug)
+    nmcli connection modify --temporary "$_unique_id" "connection.interface-name" "" &> >(ddebug)
+}
+
 # Clone and modify NM connection profiles
 #
 # This function makes use of "nmcli clone" to automatically convert ifcfg-*
@@ -328,6 +321,10 @@ clone_and_modify_nmconnection() {
     use_ipv4_or_ipv6 "$_dev" "$_uuid"
 
     nmcli connection modify --temporary uuid "$_uuid" connection.wait-device-timeout 60000 &> >(ddebug)
+    # For physical NIC i.e. non-user created NIC, ask NM to match a
+    # connection profile based on MAC address
+    _match_nmconnection_by_mac "$_uuid" "$_dev"
+
     _cloned_nmconnection_file_path=$(nmcli --get-values UUID,FILENAME connection show | sed -n "s/^${_uuid}://p")
     _tmp_nmconnection_file_path=$_DRACUT_KDUMP_NM_TMP_DIR/$(basename "$_nmconnection_file_path")
     cp "$_cloned_nmconnection_file_path" "$_tmp_nmconnection_file_path"
@@ -531,19 +528,6 @@ kdump_setup_znet() {
     echo "rd.znet=${NETTYPE},${SUBCHANNELS},${_options} rd.znet_ifname=$_netdev:${SUBCHANNELS}" > "${initdir}/etc/cmdline.d/30znet.conf"
 }
 
-kdump_get_ip_route() {
-    local _route
-    if ! _route=$(/sbin/ip -o route get to "$1" 2>&1); then
-        derror "Bad kdump network destination: $1"
-        exit 1
-    fi
-    echo "$_route"
-}
-
-kdump_get_ip_route_field() {
-    echo "$1" | sed -n -e "s/^.*\<$2\>\s\+\(\S\+\).*$/\1/p"
-}
-
 kdump_get_remote_ip() {
     local _remote _remote_temp
     _remote=$(get_remote_host "$1")
@@ -560,14 +544,13 @@ kdump_get_remote_ip() {
 # Collect netifs needed by kdump
 # $1: destination host
 kdump_collect_netif_usage() {
-    local _destaddr _srcaddr _route _netdev kdumpnic
+    local _destaddr _srcaddr _route _netdev
     local _znet_netdev _znet_conpath
 
     _destaddr=$(kdump_get_remote_ip "$1")
     _route=$(kdump_get_ip_route "$_destaddr")
     _srcaddr=$(kdump_get_ip_route_field "$_route" "src")
     _netdev=$(kdump_get_ip_route_field "$_route" "dev")
-    kdumpnic=$(kdump_setup_ifname "$_netdev")
 
     _znet_netdev=$(find_online_znet_device)
     if [[ -n $_znet_netdev ]]; then
@@ -594,8 +577,8 @@ kdump_collect_netif_usage() {
         echo "rd.neednet" >> "${initdir}/etc/cmdline.d/50neednet.conf"
     fi
 
-    if [[ ! -f ${initdir}/etc/cmdline.d/60kdumpnic.conf ]]; then
-        echo "kdumpnic=$kdumpnic" > "${initdir}/etc/cmdline.d/60kdumpnic.conf"
+    if [[ ! -f ${initdir}/etc/cmdline.d/60kdumpip.conf ]]; then
+        echo "kdump_remote_ip=$_destaddr" > "${initdir}/etc/cmdline.d/60kdumpip.conf"
     fi
 
     if is_ipv6_address "$_srcaddr"; then

--- a/dracut-module-setup.sh
+++ b/dracut-module-setup.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 kdump_module_init() {
+    # shellcheck disable=SC2154 # $initdir is a dracut variable
     if ! [[ -d "${initdir}/tmp" ]]; then
         mkdir -p "${initdir}/tmp"
     fi
@@ -9,6 +10,7 @@ kdump_module_init() {
 }
 
 check() {
+    # shellcheck disable=SC2154 # $debug is a dracut variable
     [[ $debug ]] && set -x
     #kdumpctl sets this explicitly
     if [[ -z $IN_KDUMP ]] || [[ ! -f /etc/kdump.conf ]]; then
@@ -23,6 +25,7 @@ depends() {
     kdump_module_init
 
     add_opt_module() {
+        # shellcheck disable=SC2154 # $omit_dracutmodules is a dracut variable
         [[ " $omit_dracutmodules " != *\ $1\ * ]] && _dep="$_dep $1"
     }
 
@@ -859,7 +862,7 @@ kdump_check_iscsi_targets() {
         done
         [[ -d iscsi_session ]] && kdump_setup_iscsi_device "$PWD"
     )
-
+    # shellcheck disable=SC2154 # $hostonly and $mount_needs are from dracut
     [[ $hostonly ]] || [[ $mount_needs ]] && {
         for_each_host_dev_and_slaves_all kdump_check_setup_iscsi
     }
@@ -914,6 +917,7 @@ get_pcs_fence_kdump_nodes() {
     for node in ${nodelist}; do
         # convert $node from 'uname="nodeX"' to 'nodeX'
         eval "$node"
+        # shellcheck disable=SC2154 # $uname from dracut
         nodename="$uname"
         # Skip its own node name
         if is_localhost "$nodename"; then
@@ -1047,6 +1051,7 @@ install() {
         kdump_install_random_seed
     fi
     dracut_install -o /etc/adjtime /etc/localtime
+    # shellcheck disable=SC2154 # $uname and ${initdir} from dracut
     inst "$moddir/monitor_dd_progress" "/kdumpscripts/monitor_dd_progress"
     chmod +x "${initdir}/kdumpscripts/monitor_dd_progress"
     inst "/bin/dd" "/bin/dd"
@@ -1066,6 +1071,7 @@ install() {
     inst "/lib/kdump/kdump-lib-initramfs.sh" "/lib/kdump-lib-initramfs.sh"
     inst "/lib/kdump/kdump-logger.sh" "/lib/kdump-logger.sh"
     inst "$moddir/kdump.sh" "/usr/bin/kdump.sh"
+    # shellcheck disable=SC2154 # $systemdsystemunitdir from dracut
     inst "$moddir/kdump-capture.service" "$systemdsystemunitdir/kdump-capture.service"
     systemctl -q --root "$initdir" add-wants initrd.target kdump-capture.service
     # Replace existing emergency service and emergency target

--- a/dracut-module-setup.sh
+++ b/dracut-module-setup.sh
@@ -2,6 +2,14 @@
 
 _DRACUT_KDUMP_NM_TMP_DIR="/tmp/$$-DRACUT_KDUMP_NM"
 
+_save_kdump_netifs() {
+    unique_netifs[$1]=1
+}
+
+_get_kdump_netifs() {
+    echo -n "${!unique_netifs[@]}"
+}
+
 cleanup() {
     rm -rf "$_DRACUT_KDUMP_NM_TMP_DIR"
 }
@@ -104,39 +112,6 @@ source_ifcfg_file() {
     else
         dwarning "The ifcfg file of $1 is not found!"
     fi
-}
-
-kdump_setup_dns() {
-    local _netdev="$1"
-    local _conpath="$2"
-    local _nameserver _dns _tmp array
-    local _dnsfile=${initdir}/etc/cmdline.d/42dns.conf
-
-    _tmp=$(get_nmcli_field_by_conpath "IP4.DNS" "$_conpath")
-    # shellcheck disable=SC2206
-    array=(${_tmp//|/ })
-    if [[ ${array[*]} ]]; then
-        for _dns in "${array[@]}"; do
-            echo "nameserver=$_dns" >> "$_dnsfile"
-        done
-    else
-        dwarning "Failed to get DNS info via nmcli output. Now try sourcing ifcfg script"
-        source_ifcfg_file "$_netdev"
-        [[ -n $DNS1 ]] && echo "nameserver=$DNS1" > "$_dnsfile"
-        [[ -n $DNS2 ]] && echo "nameserver=$DNS2" >> "$_dnsfile"
-    fi
-
-    while read -r content; do
-        _nameserver=$(echo "$content" | grep ^nameserver)
-        [[ -z $_nameserver ]] && continue
-
-        _dns=$(echo "$_nameserver" | awk '{print $2}')
-        [[ -z $_dns ]] && continue
-
-        if [[ ! -f $_dnsfile ]] || ! grep -q "$_dns" "$_dnsfile"; then
-            echo "nameserver=$_dns" >> "$_dnsfile"
-        fi
-    done < "/etc/resolv.conf"
 }
 
 # $1: repeat times
@@ -247,89 +222,6 @@ cal_netmask_by_prefix() {
     else
         echo -n "${_res}${_seperator}${_third_part}"
     fi
-}
-
-#$1: netdev name
-#$2: srcaddr
-#if it use static ip echo it, or echo null
-kdump_static_ip() {
-    local _netdev="$1" _srcaddr="$2" kdumpnic="$3" _ipv6_flag
-    local _netmask _gateway _ipaddr _target _nexthop _prefix
-
-    _ipaddr=$(ip addr show dev "$_netdev" permanent | awk "/ $_srcaddr\/.* /{print \$2}")
-
-    if is_ipv6_address "$_srcaddr"; then
-        _ipv6_flag="-6"
-    fi
-
-    if [[ -n $_ipaddr ]]; then
-        _gateway=$(ip $_ipv6_flag route list dev "$_netdev" \
-            | awk '/^default /{print $3}' | head -n 1)
-
-        if [[ "x" != "x"$_ipv6_flag ]]; then
-            # _ipaddr="2002::56ff:feb6:56d5/64", _netmask is the number after "/"
-            _netmask=${_ipaddr#*\/}
-            _srcaddr="[$_srcaddr]"
-            _gateway="[$_gateway]"
-        else
-            _prefix=$(cut -d'/' -f2 <<< "$_ipaddr")
-            if ! _netmask=$(cal_netmask_by_prefix "$_prefix" "$_ipv6_flag"); then
-                derror "Failed to calculate netmask for $_ipaddr"
-                exit 1
-            fi
-        fi
-        echo -n "${_srcaddr}::${_gateway}:${_netmask}::"
-    fi
-
-    while read -r _route; do
-        _target=$(echo "$_route" | awk '{print $1}')
-        _nexthop=$(echo "$_route" | awk '{print $3}')
-        if [[ "x" != "x"$_ipv6_flag ]]; then
-            _target="[$_target]"
-            _nexthop="[$_nexthop]"
-        fi
-        echo "rd.route=$_target:$_nexthop:$kdumpnic"
-    done >> "${initdir}/etc/cmdline.d/45route-static.conf" \
-        < <(/sbin/ip $_ipv6_flag route show | grep -v default \
-            | grep ".*via.* $_netdev " | grep -v "^[[:space:]]*nexthop")
-
-    kdump_handle_mulitpath_route "$_netdev" "$_srcaddr" "$kdumpnic"
-}
-
-kdump_handle_mulitpath_route() {
-    local _netdev="$1" _srcaddr="$2" kdumpnic="$3" _ipv6_flag
-    local _target _nexthop _route _weight _max_weight _rule
-
-    if is_ipv6_address "$_srcaddr"; then
-        _ipv6_flag="-6"
-    fi
-
-    while IFS="" read -r _route; do
-        if [[ $_route =~ [[:space:]]+nexthop ]]; then
-            _route=${_route##[[:space:]]}
-            # Parse multipath route, using previous _target
-            [[ $_target == 'default' ]] && continue
-            [[ $_route =~ .*via.*\ $_netdev ]] || continue
-
-            _weight=$(echo "$_route" | cut -d ' ' -f7)
-            if [[ $_weight -gt $_max_weight ]]; then
-                _nexthop=$(echo "$_route" | cut -d ' ' -f3)
-                _max_weight=$_weight
-                if [[ "x" != "x"$_ipv6_flag ]]; then
-                    _rule="rd.route=[$_target]:[$_nexthop]:$kdumpnic"
-                else
-                    _rule="rd.route=$_target:$_nexthop:$kdumpnic"
-                fi
-            fi
-        else
-            [[ -n $_rule ]] && echo "$_rule"
-            _target=$(echo "$_route" | cut -d ' ' -f1)
-            _rule="" _max_weight=0 _weight=0
-        fi
-    done >> "${initdir}/etc/cmdline.d/45route-static.conf" \
-        <<< "$(/sbin/ip $_ipv6_flag route show)"
-
-    [[ -n $_rule ]] && echo "$_rule" >> "${initdir}/etc/cmdline.d/45route-static.conf"
 }
 
 kdump_get_mac_addr() {
@@ -477,102 +369,55 @@ kdump_install_nmconnections() {
 
 kdump_setup_bridge() {
     local _netdev=$1
-    local _brif _dev _mac _kdumpdev
+    local _dev
     for _dev in "/sys/class/net/$_netdev/brif/"*; do
         [[ -e $_dev ]] || continue
         _dev=${_dev##*/}
-        _kdumpdev=$_dev
         if kdump_is_bond "$_dev"; then
-            (kdump_setup_bond "$_dev" "$(get_nmcli_connection_apath_by_ifname "$_dev")") || exit 1
+            kdump_setup_bond "$_dev" || return 1
         elif kdump_is_team "$_dev"; then
             kdump_setup_team "$_dev"
         elif kdump_is_vlan "$_dev"; then
             kdump_setup_vlan "$_dev"
-        else
-            _mac=$(kdump_get_mac_addr "$_dev")
-            _kdumpdev=$(kdump_setup_ifname "$_dev")
-            echo -n " ifname=$_kdumpdev:$_mac" >> "${initdir}/etc/cmdline.d/41bridge.conf"
         fi
-        _brif+="$_kdumpdev,"
+        _save_kdump_netifs "$_dev"
     done
-    echo " bridge=$_netdev:${_brif%,}" >> "${initdir}/etc/cmdline.d/41bridge.conf"
 }
 
-# drauct takes bond=<bondname>[:<bondslaves>:[:<options>]] syntax to parse
-#    bond. For example:
-#     bond=bond0:eth0,eth1:mode=balance-rr
 kdump_setup_bond() {
     local _netdev="$1"
-    local _conpath="$2"
-    local _dev _mac _slaves _kdumpdev _bondoptions
+    local _dev
+
     for _dev in $(< "/sys/class/net/$_netdev/bonding/slaves"); do
-        _mac=$(kdump_get_perm_addr "$_dev")
-        _kdumpdev=$(kdump_setup_ifname "$_dev")
-        echo -n " ifname=$_kdumpdev:$_mac" >> "${initdir}/etc/cmdline.d/42bond.conf"
-        _slaves+="$_kdumpdev,"
+        _save_kdump_netifs "$_dev"
     done
-    echo -n " bond=$_netdev:${_slaves%,}" >> "${initdir}/etc/cmdline.d/42bond.conf"
-
-    _bondoptions=$(get_nmcli_field_by_conpath "bond.options" "$_conpath")
-
-    if [[ -z $_bondoptions ]]; then
-        dwarning "Failed to get bond configuration via nmlci output. Now try sourcing ifcfg script."
-        source_ifcfg_file "$_netdev"
-        _bondoptions="$(echo "$BONDING_OPTS" | xargs echo | tr " " ",")"
-    fi
-
-    if [[ -z $_bondoptions ]]; then
-        derror "Get empty bond options"
-        exit 1
-    fi
-
-    echo ":$_bondoptions" >> "${initdir}/etc/cmdline.d/42bond.conf"
 }
 
 kdump_setup_team() {
     local _netdev=$1
-    local _dev _mac _slaves _kdumpdev
+    local _dev
     for _dev in $(teamnl "$_netdev" ports | awk -F':' '{print $2}'); do
-        _mac=$(kdump_get_perm_addr "$_dev")
-        _kdumpdev=$(kdump_setup_ifname "$_dev")
-        echo -n " ifname=$_kdumpdev:$_mac" >> "${initdir}/etc/cmdline.d/44team.conf"
-        _slaves+="$_kdumpdev,"
+        _save_kdump_netifs "$_dev"
     done
-    echo " team=$_netdev:${_slaves%,}" >> "${initdir}/etc/cmdline.d/44team.conf"
-    #Buggy version teamdctl outputs to stderr!
-    #Try to use the latest version of teamd.
-    if ! teamdctl "$_netdev" config dump > "${initdir}/tmp/$$-$_netdev.conf"; then
-        derror "teamdctl failed."
-        exit 1
-    fi
-    inst_dir /etc/teamd
-    inst_simple "${initdir}/tmp/$$-$_netdev.conf" "/etc/teamd/$_netdev.conf"
-    rm -f "${initdir}/tmp/$$-$_netdev.conf"
 }
 
 kdump_setup_vlan() {
     local _netdev=$1
-    local _phydev
-    local _netmac
-    local _kdumpdev
+    local _parent_netif
 
-    _phydev="$(awk '/^Device:/{print $2}' /proc/net/vlan/"$_netdev")"
-    _netmac="$(kdump_get_mac_addr "$_phydev")"
+    _parent_netif="$(awk '/^Device:/{print $2}' /proc/net/vlan/"$_netdev")"
 
     #Just support vlan over bond and team
-    if kdump_is_bridge "$_phydev"; then
+    if kdump_is_bridge "$_parent_netif"; then
         derror "Vlan over bridge is not supported!"
         exit 1
-    elif kdump_is_bond "$_phydev"; then
-        (kdump_setup_bond "$_phydev" "$(get_nmcli_connection_apath_by_ifname "$_phydev")") || exit 1
-        echo " vlan=$(kdump_setup_ifname "$_netdev"):$_phydev" > "${initdir}/etc/cmdline.d/43vlan.conf"
-    elif kdump_is_team "$_phydev"; then
-        (kdump_setup_team "$_phydev") || exit 1
-        echo " vlan=$(kdump_setup_ifname "$_netdev"):$_phydev" > "${initdir}/etc/cmdline.d/43vlan.conf"
-    else
-        _kdumpdev="$(kdump_setup_ifname "$_phydev")"
-        echo " vlan=$(kdump_setup_ifname "$_netdev"):$_kdumpdev ifname=$_kdumpdev:$_netmac" > "${initdir}/etc/cmdline.d/43vlan.conf"
+    elif kdump_is_bond "$_parent_netif"; then
+        kdump_setup_bond "$_parent_netif" || return 1
+    elif kdump_is_team "$_parent_netif"; then
+        kdump_setup_team "$_parent_netif" || return 1
     fi
+
+    _save_kdump_netifs "$_parent_netif"
 }
 
 # find online znet device
@@ -659,20 +504,16 @@ kdump_get_remote_ip() {
     echo "$_remote"
 }
 
-# Setup dracut to bring up network interface that enable
-# initramfs accessing giving destination
+# Collect netifs needed by kdump
 # $1: destination host
-kdump_install_net() {
-    local _destaddr _srcaddr _route _netdev _conpath kdumpnic
-    local _static _proto _ip_conf _ip_opts _ifname_opts
+kdump_collect_netif_usage() {
+    local _destaddr _srcaddr _route _netdev kdumpnic
     local _znet_netdev _znet_conpath
 
     _destaddr=$(kdump_get_remote_ip "$1")
     _route=$(kdump_get_ip_route "$_destaddr")
     _srcaddr=$(kdump_get_ip_route_field "$_route" "src")
     _netdev=$(kdump_get_ip_route_field "$_route" "dev")
-    _conpath=$(get_nmcli_connection_apath_by_ifname "$_netdev")
-    _netmac=$(kdump_get_mac_addr "$_netdev")
     kdumpnic=$(kdump_setup_ifname "$_netdev")
 
     _znet_netdev=$(find_online_znet_device)
@@ -684,58 +525,42 @@ kdump_install_net() {
         fi
     fi
 
-    _static=$(kdump_static_ip "$_netdev" "$_srcaddr" "$kdumpnic")
-    if [[ -n $_static ]]; then
-        _proto=none
-    elif is_ipv6_address "$_srcaddr"; then
-        _proto=auto6
-    else
-        _proto=dhcp
-    fi
-
-    _ip_conf="${initdir}/etc/cmdline.d/40ip.conf"
-    _ip_opts=" ip=${_static}$kdumpnic:${_proto}"
-
-    # dracut doesn't allow duplicated configuration for same NIC, even they're exactly the same.
-    # so we have to avoid adding duplicates
-    # We should also check /proc/cmdline for existing ip=xx arg.
-    # For example, iscsi boot will specify ip=xxx arg in cmdline.
-    if [[ ! -f $_ip_conf ]] || ! grep -q "$_ip_opts" "$_ip_conf" \
-        && ! grep -q "ip=[^[:space:]]*$_netdev" /proc/cmdline; then
-        echo "$_ip_opts" >> "$_ip_conf"
-    fi
-
     if kdump_is_bridge "$_netdev"; then
         kdump_setup_bridge "$_netdev"
     elif kdump_is_bond "$_netdev"; then
-        (kdump_setup_bond "$_netdev" "$_conpath") || exit 1
+        kdump_setup_bond "$_netdev" || return 1
     elif kdump_is_team "$_netdev"; then
         kdump_setup_team "$_netdev"
     elif kdump_is_vlan "$_netdev"; then
         kdump_setup_vlan "$_netdev"
-    else
-        _ifname_opts=" ifname=$kdumpnic:$_netmac"
-        echo "$_ifname_opts" >> "$_ip_conf"
     fi
-
-    kdump_setup_dns "$_netdev" "$_conpath"
+    _save_kdump_netifs "$_netdev"
 
     if [[ ! -f ${initdir}/etc/cmdline.d/50neednet.conf ]]; then
         # network-manager module needs this parameter
         echo "rd.neednet" >> "${initdir}/etc/cmdline.d/50neednet.conf"
     fi
 
-    # Save netdev used for kdump as cmdline
-    # Whoever calling kdump_install_net() is setting up the default gateway,
-    # ie. bootdev/kdumpnic. So don't override the setting if calling
-    # kdump_install_net() for another time. For example, after setting eth0 as
-    # the default gate way for network dump, eth1 in the fence kdump path will
-    # call kdump_install_net again and we don't want eth1 to be the default
-    # gateway.
-    if [[ ! -f ${initdir}/etc/cmdline.d/60kdumpnic.conf ]] \
-        && [[ ! -f ${initdir}/etc/cmdline.d/70bootdev.conf ]]; then
+    if [[ ! -f ${initdir}/etc/cmdline.d/60kdumpnic.conf ]]; then
         echo "kdumpnic=$kdumpnic" > "${initdir}/etc/cmdline.d/60kdumpnic.conf"
-        echo "bootdev=$kdumpnic" > "${initdir}/etc/cmdline.d/70bootdev.conf"
+    fi
+
+    if is_ipv6_address "$_srcaddr"; then
+        ipv6_usage[$_netdev]=1
+    else
+        ipv4_usage[$_netdev]=1
+    fi
+}
+
+# Setup dracut to bring up network interface that enable
+# initramfs accessing giving destination
+kdump_install_net() {
+    local _netifs
+
+    _netifs=$(_get_kdump_netifs)
+    if [[ -n "$_netifs" ]]; then
+        kdump_install_nmconnections
+        apply_nm_initrd_generator_timeouts
     fi
 }
 
@@ -774,7 +599,7 @@ default_dump_target_install_conf() {
 
     _fstype=$(get_fs_type_from_target "$_target")
     if is_fs_type_nfs "$_fstype"; then
-        kdump_install_net "$_target"
+        kdump_collect_netif_usage "$_target"
         _fstype="nfs"
     else
         _target=$(kdump_get_persistent_dev "$_target")
@@ -810,11 +635,11 @@ kdump_install_conf() {
                 sed -i -e "s#^${_opt}[[:space:]]\+$_val#$_opt $_pdev#" "${initdir}/tmp/$$-kdump.conf"
                 ;;
             ssh | nfs)
-                kdump_install_net "$_val"
+                kdump_collect_netif_usage "$_val"
                 ;;
             dracut_args)
                 if [[ $(get_dracut_args_fstype "$_val") == nfs* ]]; then
-                    kdump_install_net "$(get_dracut_args_target "$_val")"
+                    kdump_collect_netif_usage "$(get_dracut_args_target "$_val")"
                 fi
                 ;;
             kdump_pre | kdump_post | extra_bins)
@@ -936,7 +761,7 @@ kdump_setup_iscsi_device() {
 
     [[ -n $username_in ]] && userpwd_in_str=":$username_in:$password_in"
 
-    kdump_install_net "$tgt_ipaddr"
+    kdump_collect_netif_usage "$tgt_ipaddr"
 
     # prepare netroot= command line
     # FIXME: Do we need to parse and set other parameters like protocol, port
@@ -1101,7 +926,7 @@ kdump_configure_fence_kdump() {
 
     # setup network for each node
     for node in ${nodes}; do
-        kdump_install_net "$node"
+        kdump_collect_netif_usage "$node"
     done
 
     dracut_install /etc/hosts
@@ -1215,6 +1040,8 @@ install() {
     if is_nfs_dump_target || is_ssh_dump_target; then
         inst "ip"
     fi
+
+    kdump_install_net
 
     # For the lvm type target under kdump, in /etc/lvm/lvm.conf we can
     # safely replace "reserved_memory=XXXX"(default value is 8192) with

--- a/dracut-module-setup.sh
+++ b/dracut-module-setup.sh
@@ -1016,10 +1016,12 @@ kdump_install_systemd_conf() {
     # unneccessary memory consumption and make console output more useful.
     # Only do so for non fadump image.
     mkdir -p "${initdir}/etc/systemd/journald.conf.d"
-    echo "[Journal]" > "${initdir}/etc/systemd/journald.conf.d/kdump.conf"
-    echo "Storage=volatile" >> "${initdir}/etc/systemd/journald.conf.d/kdump.conf"
-    echo "ReadKMsg=no" >> "${initdir}/etc/systemd/journald.conf.d/kdump.conf"
-    echo "ForwardToConsole=yes" >> "${initdir}/etc/systemd/journald.conf.d/kdump.conf"
+    {
+        echo "[Journal]"
+        echo "Storage=volatile"
+        echo "ReadKMsg=no"
+        echo "ForwardToConsole=yes"
+    } > "${initdir}/etc/systemd/journald.conf.d/kdump.conf"
 }
 
 remove_cpu_online_rule() {

--- a/dracut-module-setup.sh
+++ b/dracut-module-setup.sh
@@ -270,17 +270,17 @@ kdump_static_ip() {
         echo -n "${_srcaddr}::${_gateway}:${_netmask}::"
     fi
 
-    /sbin/ip $_ipv6_flag route show | grep -v default \
-        | grep ".*via.* $_netdev " | grep -v "^[[:space:]]*nexthop" \
-        | while read -r _route; do
-            _target=$(echo "$_route" | awk '{print $1}')
-            _nexthop=$(echo "$_route" | awk '{print $3}')
-            if [[ "x" != "x"$_ipv6_flag ]]; then
-                _target="[$_target]"
-                _nexthop="[$_nexthop]"
-            fi
-            echo "rd.route=$_target:$_nexthop:$kdumpnic"
-        done >> "${initdir}/etc/cmdline.d/45route-static.conf"
+    while read -r _route; do
+        _target=$(echo "$_route" | awk '{print $1}')
+        _nexthop=$(echo "$_route" | awk '{print $3}')
+        if [[ "x" != "x"$_ipv6_flag ]]; then
+            _target="[$_target]"
+            _nexthop="[$_nexthop]"
+        fi
+        echo "rd.route=$_target:$_nexthop:$kdumpnic"
+    done >> "${initdir}/etc/cmdline.d/45route-static.conf" \
+        < <(/sbin/ip $_ipv6_flag route show | grep -v default \
+            | grep ".*via.* $_netdev " | grep -v "^[[:space:]]*nexthop")
 
     kdump_handle_mulitpath_route "$_netdev" "$_srcaddr" "$kdumpnic"
 }

--- a/dracut-module-setup.sh
+++ b/dracut-module-setup.sh
@@ -390,6 +390,36 @@ EOF
     inst "$_netif_allowlist_nm_conf" "/etc/NetworkManager/conf.d/10-kdump-netif_allowlist.conf"
 }
 
+_get_nic_driver() {
+    ethtool -i "$1" | sed -n -E "s/driver: (.*)/\1/p"
+}
+
+kdump_install_nic_driver() {
+    local _netif _driver _drivers
+
+    _drivers=()
+
+    for _netif in $1; do
+        _driver=$(_get_nic_driver "$_netif")
+        if [[ -z $_driver ]]; then
+            derror "Failed to get the driver of $_netif"
+            exit 1
+        fi
+
+        if [[ $_driver == "802.1Q VLAN Support" ]]; then
+            # ethtool somehow doesn't return the driver name for a VLAN NIC
+            _driver=8021q
+        elif [[ $_driver == "team" ]]; then
+            # install the team mode drivers like team_mode_roundrobin.ko as well
+            _driver='=drivers/net/team'
+        fi
+
+        _drivers+=("$_driver")
+    done
+
+    instmods "${_drivers[@]}"
+}
+
 kdump_setup_bridge() {
     local _netdev=$1
     local _dev
@@ -585,6 +615,7 @@ kdump_install_net() {
         kdump_install_nmconnections
         apply_nm_initrd_generator_timeouts
         kdump_install_nm_netif_allowlist "$_netifs"
+        kdump_install_nic_driver "$_netifs"
     fi
 }
 

--- a/dracut-module-setup.sh
+++ b/dracut-module-setup.sh
@@ -448,6 +448,9 @@ kdump_setup_vlan() {
     elif kdump_is_bond "$_phydev"; then
         (kdump_setup_bond "$_phydev" "$(get_nmcli_connection_apath_by_ifname "$_phydev")") || exit 1
         echo " vlan=$(kdump_setup_ifname "$_netdev"):$_phydev" > "${initdir}/etc/cmdline.d/43vlan.conf"
+    elif kdump_is_team "$_phydev"; then
+        (kdump_setup_team "$_phydev") || exit 1
+        echo " vlan=$(kdump_setup_ifname "$_netdev"):$_phydev" > "${initdir}/etc/cmdline.d/43vlan.conf"
     else
         _kdumpdev="$(kdump_setup_ifname "$_phydev")"
         echo " vlan=$(kdump_setup_ifname "$_netdev"):$_kdumpdev ifname=$_kdumpdev:$_netmac" > "${initdir}/etc/cmdline.d/43vlan.conf"

--- a/dracut-module-setup.sh
+++ b/dracut-module-setup.sh
@@ -368,6 +368,22 @@ kdump_setup_ifname() {
     echo "$_ifname"
 }
 
+apply_nm_initrd_generator_timeouts() {
+    local _timeout_conf
+
+    _timeout_conf=$_DRACUT_KDUMP_NM_TMP_DIR/timeout_conf
+    cat << EOF > "$_timeout_conf"
+[device-95-kdump]
+carrier-wait-timeout=30000
+
+[connection-95-kdump]
+ipv4.dhcp-timeout=90
+ipv6.dhcp-timeout=90
+EOF
+
+    inst "$_timeout_conf" "/etc/NetworkManager/conf.d/95-kdump-timeouts.conf"
+}
+
 use_ipv4_or_ipv6() {
     local _netif=$1 _uuid=$2
 
@@ -419,6 +435,7 @@ clone_and_modify_nmconnection() {
 
     use_ipv4_or_ipv6 "$_dev" "$_uuid"
 
+    nmcli connection modify --temporary uuid "$_uuid" connection.wait-device-timeout 60000 &> >(ddebug)
     _cloned_nmconnection_file_path=$(nmcli --get-values UUID,FILENAME connection show | sed -n "s/^${_uuid}://p")
     _tmp_nmconnection_file_path=$_DRACUT_KDUMP_NM_TMP_DIR/$(basename "$_nmconnection_file_path")
     cp "$_cloned_nmconnection_file_path" "$_tmp_nmconnection_file_path"

--- a/dracut-module-setup.sh
+++ b/dracut-module-setup.sh
@@ -368,6 +368,24 @@ kdump_setup_ifname() {
     echo "$_ifname"
 }
 
+use_ipv4_or_ipv6() {
+    local _netif=$1 _uuid=$2
+
+    if [[ -v "ipv4_usage[$_netif]" ]]; then
+        nmcli connection modify --temporary "$_uuid" ipv4.may-fail no &> >(ddebug)
+    fi
+
+    if [[ -v "ipv6_usage[$_netif]" ]]; then
+        nmcli connection modify --temporary "$_uuid" ipv6.may-fail no &> >(ddebug)
+    fi
+
+    if [[ -v "ipv4_usage[$_netif]" ]] && [[ ! -v "ipv6_usage[$_netif]" ]]; then
+        nmcli connection modify --temporary "$_uuid" ipv6.method disabled &> >(ddebug)
+    elif [[ ! -v "ipv4_usage[$_netif]" ]] && [[ -v "ipv6_usage[$_netif]" ]]; then
+        nmcli connection modify --temporary "$_uuid" ipv4.method disabled &> >(ddebug)
+    fi
+}
+
 _clone_nmconnection() {
     local _clone_output _name _unique_id
 
@@ -398,6 +416,8 @@ clone_and_modify_nmconnection() {
         derror "Failed to clone $_old_uuid"
         exit 1
     fi
+
+    use_ipv4_or_ipv6 "$_dev" "$_uuid"
 
     _cloned_nmconnection_file_path=$(nmcli --get-values UUID,FILENAME connection show | sed -n "s/^${_uuid}://p")
     _tmp_nmconnection_file_path=$_DRACUT_KDUMP_NM_TMP_DIR/$(basename "$_nmconnection_file_path")
@@ -1112,7 +1132,7 @@ remove_cpu_online_rule() {
 }
 
 install() {
-    declare -A unique_netifs
+    declare -A unique_netifs ipv4_usage ipv6_usage
     local arch
 
     kdump_module_init

--- a/dracut-module-setup.sh
+++ b/dracut-module-setup.sh
@@ -367,6 +367,29 @@ kdump_install_nmconnections() {
     echo > "${initdir}/usr/libexec/nm-initrd-generator"
 }
 
+kdump_install_nm_netif_allowlist() {
+    local _netif _except_netif _netif_allowlist _netif_allowlist_nm_conf
+
+    for _netif in $1; do
+        _per_mac=$(kdump_get_perm_addr "$_netif")
+        if [[ "$_per_mac" != 'not set' ]]; then
+            _except_netif="mac:$_per_mac"
+        else
+            _except_netif="interface-name:$_netif"
+        fi
+        _netif_allowlist="${_netif_allowlist}except:${_except_netif};"
+    done
+
+    _netif_allowlist_nm_conf=$_DRACUT_KDUMP_NM_TMP_DIR/netif_allowlist_nm_conf
+    cat << EOF > "$_netif_allowlist_nm_conf"
+[device-others]
+match-device=${_netif_allowlist}
+managed=false
+EOF
+
+    inst "$_netif_allowlist_nm_conf" "/etc/NetworkManager/conf.d/10-kdump-netif_allowlist.conf"
+}
+
 kdump_setup_bridge() {
     local _netdev=$1
     local _dev
@@ -561,6 +584,7 @@ kdump_install_net() {
     if [[ -n "$_netifs" ]]; then
         kdump_install_nmconnections
         apply_nm_initrd_generator_timeouts
+        kdump_install_nm_netif_allowlist "$_netifs"
     fi
 }
 

--- a/dracut-module-setup.sh
+++ b/dracut-module-setup.sh
@@ -468,6 +468,11 @@ kdump_install_nmconnections() {
             exit 1
         fi
     done <<< "$(nmcli -t -f device,filename connection show --active)"
+
+    # Stop dracut 35network-manger to calling nm-initrd-generator.
+    # Note this line of code can be removed after NetworkManager >= 1.35.2
+    # gets released.
+    echo > "${initdir}/usr/libexec/nm-initrd-generator"
 }
 
 kdump_setup_bridge() {

--- a/dracut-module-setup.sh
+++ b/dracut-module-setup.sh
@@ -387,7 +387,7 @@ kdump_setup_bond() {
     local _netdev="$1"
     local _conpath="$2"
     local _dev _mac _slaves _kdumpdev _bondoptions
-    for _dev in $(cat "/sys/class/net/$_netdev/bonding/slaves"); do
+    for _dev in $(< "/sys/class/net/$_netdev/bonding/slaves"); do
         _mac=$(kdump_get_perm_addr "$_dev")
         _kdumpdev=$(kdump_setup_ifname "$_dev")
         echo -n " ifname=$_kdumpdev:$_mac" >> "${initdir}/etc/cmdline.d/42bond.conf"

--- a/kdump-dep-generator.sh
+++ b/kdump-dep-generator.sh
@@ -11,13 +11,13 @@
 dest_dir="/tmp"
 
 if [ -n "$1" ]; then
-    dest_dir=$1
+	dest_dir=$1
 fi
 
 systemd_dir=/usr/lib/systemd/system
 kdump_wants=$dest_dir/kdump.service.wants
 
 if is_ssh_dump_target; then
-    mkdir -p $kdump_wants
-    ln -sf $systemd_dir/network-online.target $kdump_wants/
+	mkdir -p $kdump_wants
+	ln -sf $systemd_dir/network-online.target $kdump_wants/
 fi

--- a/kdump-dep-generator.sh
+++ b/kdump-dep-generator.sh
@@ -18,6 +18,6 @@ systemd_dir=/usr/lib/systemd/system
 kdump_wants=$dest_dir/kdump.service.wants
 
 if is_ssh_dump_target; then
-	mkdir -p $kdump_wants
-	ln -sf $systemd_dir/network-online.target $kdump_wants/
+	mkdir -p "$kdump_wants"
+	ln -sf $systemd_dir/network-online.target "$kdump_wants"/
 fi

--- a/kdump-lib-initramfs.sh
+++ b/kdump-lib-initramfs.sh
@@ -37,6 +37,7 @@ is_mounted()
 # $2: mount source type
 # $3: mount source
 # $4: extra args
+# shellcheck disable=SC2086 # $4 means extra args which nees to word-splitted
 get_mount_info()
 {
 	__kdump_mnt=$(findmnt -k -n -r -o "$1" "--$2" "$3" $4)

--- a/kdump-lib-initramfs.sh
+++ b/kdump-lib-initramfs.sh
@@ -165,3 +165,17 @@ is_lvm2_thinp_device()
 
 	[ -n "$_lvm2_thin_device" ]
 }
+
+kdump_get_ip_route()
+{
+	if ! _route=$(/sbin/ip -o route get to "$1" 2>&1); then
+		derror "Bad kdump network destination: $1"
+		exit 1
+	fi
+	echo "$_route"
+}
+
+kdump_get_ip_route_field()
+{
+	echo "$1" | sed -n -e "s/^.*\<$2\>\s\+\(\S\+\).*$/\1/p"
+}

--- a/kdump-lib-initramfs.sh
+++ b/kdump-lib-initramfs.sh
@@ -4,9 +4,10 @@
 # not be the default shell. Any code added must be POSIX compliant.
 
 DEFAULT_PATH="/var/crash/"
+# shellcheck disable=SC2034
 DEFAULT_SSHKEY="/root/.ssh/kdump_id_rsa"
 KDUMP_CONFIG_FILE="/etc/kdump.conf"
-FENCE_KDUMP_CONFIG_FILE="/etc/sysconfig/fence_kdump"
+# shellcheck disable=SC2034
 FENCE_KDUMP_SEND="/usr/libexec/fence_kdump_send"
 LVM_CONF="/etc/lvm/lvm.conf"
 

--- a/kdump-lib.sh
+++ b/kdump-lib.sh
@@ -8,6 +8,8 @@ else
 	. /lib/kdump/kdump-lib-initramfs.sh
 fi
 
+# shellcheck disable=SC2034
+FENCE_KDUMP_CONFIG_FILE="/etc/sysconfig/fence_kdump"
 FADUMP_ENABLED_SYS_NODE="/sys/kernel/fadump_enabled"
 
 is_fadump_capable()
@@ -430,7 +432,7 @@ get_ifcfg_filename()
 # returns 1 otherwise
 is_dracut_mod_omitted()
 {
-	local dracut_args dracut_mod=$1
+	local dracut_mod=$1
 
 	set -- $(kdump_get_conf_val dracut_args)
 	while [ $# -gt 0 ]; do
@@ -751,8 +753,10 @@ prepare_kdump_bootinfo()
 	if [[ ! -w $KDUMP_BOOTDIR ]]; then
 		var_target_initrd_dir="/var/lib/kdump"
 		mkdir -p "$var_target_initrd_dir"
+		# shellcheck disable=SC2034 # KDUMP_INITRD is used by kdumpctl
 		KDUMP_INITRD="$var_target_initrd_dir/$kdump_initrd_base"
 	else
+		# shellcheck disable=SC2034 # KDUMP_INITRD is used by kdumpctl
 		KDUMP_INITRD="$KDUMP_BOOTDIR/$kdump_initrd_base"
 	fi
 }

--- a/kdump-lib.sh
+++ b/kdump-lib.sh
@@ -867,7 +867,7 @@ get_recommend_size()
 	while read -r -d , range; do
 		# need to use non-default IFS as double spaces are used as a
 		# single delimiter while commas aren't...
-		IFS=, read start start_unit end end_unit size <<< \
+		IFS=, read -r start start_unit end end_unit size <<< \
 			"$(echo "$range" | sed -n "s/\([0-9]\+\)\([GT]\?\)-\([0-9]*\)\([GT]\?\):\([0-9]\+[MG]\)/\1,\2,\3,\4,\5/p")"
 
 		# aka. 102400T
@@ -889,6 +889,7 @@ get_recommend_size()
 
 # get default crashkernel
 # $1 dump mode, if not specified, dump_mode will be judged by is_fadump_capable
+# shellcheck disable=SC2120 # kdumpctl will call this func with an argument
 kdump_get_arch_recommend_crashkernel()
 {
 	local _arch _ck_cmdline _dump_mode

--- a/kdump-lib.sh
+++ b/kdump-lib.sh
@@ -843,7 +843,7 @@ PROC_IOMEM=/proc/iomem
 get_system_size()
 {
 	sum=$(sed -n "s/\s*\([0-9a-fA-F]\+\)-\([0-9a-fA-F]\+\) : System RAM$/+ 0x\2 - 0x\1 + 1/p" $PROC_IOMEM)
-	echo $(( (sum) / 1024 / 1024 / 1024))
+	echo $(((sum) / 1024 / 1024 / 1024))
 }
 
 # Return the recommended size for the reserved crashkernel memory
@@ -941,7 +941,7 @@ get_luks_crypt_dev()
 
 	[[ -b /dev/block/$1 ]] || return 1
 
-	_type=$(blkid -u filesystem,crypto -o export -- "/dev/block/$1" | \
+	_type=$(blkid -u filesystem,crypto -o export -- "/dev/block/$1" |
 		sed -n -E "s/^TYPE=(.*)$/\1/p")
 	[[ $_type == "crypto_LUKS" ]] && echo "$1"
 

--- a/kdump-lib.sh
+++ b/kdump-lib.sh
@@ -183,7 +183,7 @@ get_bind_mount_source()
 	local _fsroot _src_nofsroot
 
 	_mnt=$(df "$1" | tail -1 | awk '{print $NF}')
-	_path=${1#$_mnt}
+	_path=${1#"$_mnt"}
 
 	_src=$(get_mount_info SOURCE target "$_mnt" -f)
 	_opt=$(get_mount_info OPTIONS target "$_mnt" -f)
@@ -200,7 +200,7 @@ get_bind_mount_source()
 		echo "$_mnt$_path" && return
 	fi
 
-	_fsroot=${_src#${_src_nofsroot}[}
+	_fsroot=${_src#"${_src_nofsroot}"[}
 	_fsroot=${_fsroot%]}
 	_mnt=$(get_mount_info TARGET source "$_src_nofsroot" -f)
 
@@ -209,7 +209,7 @@ get_bind_mount_source()
 		local _subvol
 		_subvol=${_opt#*subvol=}
 		_subvol=${_subvol%,*}
-		_fsroot=${_fsroot#$_subvol}
+		_fsroot=${_fsroot#"$_subvol"}
 	fi
 	echo "$_mnt$_fsroot$_path"
 }

--- a/kdump-lib.sh
+++ b/kdump-lib.sh
@@ -536,10 +536,10 @@ remove_cmdline_param()
 #
 get_bootcpu_apicid()
 {
-	awk '                                                       \
-        BEGIN { CPU = "-1"; }                                   \
-        $1=="processor" && $2==":"      { CPU = $NF; }          \
-        CPU=="0" && /^apicid/           { print $NF; }          \
+	awk '
+        BEGIN { CPU = "-1"; }
+        $1=="processor" && $2==":"      { CPU = $NF; }
+        CPU=="0" && /^apicid/           { print $NF; }
         ' \
 		/proc/cpuinfo
 }

--- a/kdump-lib.sh
+++ b/kdump-lib.sh
@@ -434,6 +434,7 @@ is_dracut_mod_omitted()
 {
 	local dracut_mod=$1
 
+	# shellcheck disable=SC2046 # a known issue https://github.com/koalaman/shellcheck/issues/2335
 	set -- $(kdump_get_conf_val dracut_args)
 	while [ $# -gt 0 ]; do
 		case $1 in

--- a/kdump-lib.sh
+++ b/kdump-lib.sh
@@ -1039,6 +1039,7 @@ get_kernel_size()
 		try_decompress '(\265/\375' xxx unzstd "$img" "$tmp"
 
 	# Finally check for uncompressed images or objects:
+	# shellcheck disable=SC2181 # to improve readability
 	[[ $? -eq 0 ]] && get_vmlinux_size "$tmp" && return 0
 
 	# Fallback to use iomem

--- a/kdump-lib.sh
+++ b/kdump-lib.sh
@@ -256,7 +256,7 @@ kdump_get_persistent_dev()
 		dev=$(blkid -L "${dev#LABEL=}")
 		;;
 	esac
-	echo $(get_persistent_dev "$dev")
+	get_persistent_dev "$dev"
 }
 
 is_ostree()

--- a/kdump-logger.sh
+++ b/kdump-logger.sh
@@ -97,8 +97,11 @@ dlog_init()
 		kdump_stdloglvl=0
 		kdump_kmsgloglvl=0
 	else
+		# shellcheck disable=SC2153 # KDUMP_*LOGLVL is read from /etc/kdump/sysconfig by file that source kdump-logger.sh
 		kdump_stdloglvl=$KDUMP_STDLOGLVL
+		# shellcheck disable=SC2153
 		kdump_sysloglvl=$KDUMP_SYSLOGLVL
+		# shellcheck disable=SC2153
 		kdump_kmsgloglvl=$KDUMP_KMSGLOGLVL
 	fi
 

--- a/kdump-migrate-action.sh
+++ b/kdump-migrate-action.sh
@@ -2,7 +2,7 @@
 
 systemctl is-active kdump
 if [ $? -ne 0 ]; then
-        exit 0
+	exit 0
 fi
 
 /usr/lib/kdump/kdump-restart.sh

--- a/kdump-migrate-action.sh
+++ b/kdump-migrate-action.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 
-systemctl is-active kdump
-if [ $? -ne 0 ]; then
+if ! systemctl is-active kdump; then
 	exit 0
 fi
 

--- a/kdump-restart.sh
+++ b/kdump-restart.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 export PATH="$PATH:/usr/bin:/usr/sbin"
 
-exec >>/var/log/kdump-migration.log 2>&1
+exec >> /var/log/kdump-migration.log 2>&1
 
 echo "kdump: Partition Migration detected. Rebuilding initramfs image to reload."
 /usr/bin/kdumpctl rebuild

--- a/kdumpctl
+++ b/kdumpctl
@@ -722,7 +722,7 @@ check_ssh_config()
 
 	[[ "${OPT[_fstype]}" == ssh ]] || return 0
 
-	target=$(ssh -G "${OPT[_target]}" | sed  -n -e "s/^hostname[[:space:]]\+\([^[:space:]]*\).*$/\1/p")
+	target=$(ssh -G "${OPT[_target]}" | sed -n -e "s/^hostname[[:space:]]\+\([^[:space:]]*\).*$/\1/p")
 	[[ ${OPT[_target]} =~ .*@.* ]] || return 1
 	if [[ ${OPT[_target]#*@} != "$target" ]]; then
 		derror "Invalid ssh destination ${OPT[_target]} provided."
@@ -790,7 +790,7 @@ propagate_ssh_key()
 
 	parse_config || return 1
 
-	if [[ ${OPT[_fstype]} != ssh ]] ; then
+	if [[ ${OPT[_fstype]} != ssh ]]; then
 		derror "No ssh destination defined in $KDUMP_CONFIG_FILE."
 		derror "Please verify that $KDUMP_CONFIG_FILE contains 'ssh <user>@<host>' and that it is properly formatted."
 		exit 1
@@ -1483,30 +1483,30 @@ reset_crashkernel()
 
 	for _opt in "$@"; do
 		case "$_opt" in
-			--fadump=*)
-				_val=${_opt#*=}
-				if _dump_mode=$(get_dump_mode_by_fadump_val $_val); then
-					_fadump_val=$_val
-				else
-					derror "failed to determine dump mode"
-					exit
-				fi
-				;;
-			--kernel=*)
-				_val=${_opt#*=}
-				if ! _valid_grubby_kernel_path $_val; then
-					derror "Invalid $_opt, please specify a valid kernel path, ALL or DEFAULT"
-					exit
-				fi
-				_grubby_kernel_path=$_val
-				;;
-			--reboot)
-				_reboot=yes
-				;;
-			*)
-				derror "$_opt not recognized"
-				exit 1
-				;;
+		--fadump=*)
+			_val=${_opt#*=}
+			if _dump_mode=$(get_dump_mode_by_fadump_val $_val); then
+				_fadump_val=$_val
+			else
+				derror "failed to determine dump mode"
+				exit
+			fi
+			;;
+		--kernel=*)
+			_val=${_opt#*=}
+			if ! _valid_grubby_kernel_path $_val; then
+				derror "Invalid $_opt, please specify a valid kernel path, ALL or DEFAULT"
+				exit
+			fi
+			_grubby_kernel_path=$_val
+			;;
+		--reboot)
+			_reboot=yes
+			;;
+		*)
+			derror "$_opt not recognized"
+			exit 1
+			;;
 		esac
 	done
 
@@ -1565,10 +1565,10 @@ reset_crashkernel()
 	if [[ -z $_grubby_kernel_path ]]; then
 		if [[ -z $KDUMP_KERNELVER ]] ||
 			! _kernel_path=$(_find_kernel_path_by_release "$KDUMP_KERNELVER"); then
-					if ! _kernel_path=$(_get_current_running_kernel_path); then
-						derror "no running kernel found"
-						exit 1
-					fi
+			if ! _kernel_path=$(_get_current_running_kernel_path); then
+				derror "no running kernel found"
+				exit 1
+			fi
 		fi
 		_kernels=$_kernel_path
 	else
@@ -1644,9 +1644,9 @@ update_crashkernel_in_grub_etc_default_after_update()
 	_new_default_crashkernel=${_crashkernel_vals[new_${_dump_mode}]}
 
 	if [[ $_crashkernel == auto ]] ||
-		  [[ $_crashkernel == "$_old_default_crashkernel" &&
-		     $_new_default_crashkernel != "$_old_default_crashkernel" ]]; then
-			_update_kernel_arg_in_grub_etc_default crashkernel "$_new_default_crashkernel"
+		[[ $_crashkernel == "$_old_default_crashkernel" &&
+			$_new_default_crashkernel != "$_old_default_crashkernel" ]]; then
+		_update_kernel_arg_in_grub_etc_default crashkernel "$_new_default_crashkernel"
 	fi
 }
 

--- a/mkdumprd
+++ b/mkdumprd
@@ -27,7 +27,7 @@ SAVE_PATH=$(get_save_path)
 OVERRIDE_RESETTABLE=0
 
 extra_modules=""
-dracut_args=(--add kdumpbase --quiet --hostonly --hostonly-cmdline --hostonly-i18n --hostonly-mode strict -o "plymouth resume ifcfg earlykdump")
+dracut_args=(--add kdumpbase --quiet --hostonly --hostonly-cmdline --hostonly-i18n --hostonly-mode strict --hostonly-nics '' -o "plymouth resume ifcfg earlykdump")
 
 MKDUMPRD_TMPDIR="$(mktemp -d -t mkdumprd.XXXXXX)"
 [ -d "$MKDUMPRD_TMPDIR" ] || perror_exit "dracut: mktemp -p -d -t dracut.XXXXXX failed."

--- a/mkdumprd
+++ b/mkdumprd
@@ -33,6 +33,7 @@ MKDUMPRD_TMPDIR="$(mktemp -d -t mkdumprd.XXXXXX)"
 [ -d "$MKDUMPRD_TMPDIR" ] || perror_exit "dracut: mktemp -p -d -t dracut.XXXXXX failed."
 MKDUMPRD_TMPMNT="$MKDUMPRD_TMPDIR/target"
 
+# shellcheck disable=SC2154 # known issue of shellcheck https://github.com/koalaman/shellcheck/issues/1299
 trap '
     ret=$?;
     is_mounted $MKDUMPRD_TMPMNT && umount -f $MKDUMPRD_TMPMNT;

--- a/mkfadumprd
+++ b/mkfadumprd
@@ -19,6 +19,8 @@ fi
 
 MKFADUMPRD_TMPDIR="$(mktemp -d -t mkfadumprd.XXXXXX)"
 [ -d "$MKFADUMPRD_TMPDIR" ] || perror_exit "mkfadumprd: mktemp -d -t mkfadumprd.XXXXXX failed."
+
+# shellcheck disable=SC2154 # known issue of shellcheck https://github.com/koalaman/shellcheck/issues/1299
 trap '
     ret=$?;
     [[ -d $MKFADUMPRD_TMPDIR ]] && rm --one-file-system -rf -- "$MKFADUMPRD_TMPDIR";

--- a/spec/kdumpctl_general_spec.sh
+++ b/spec/kdumpctl_general_spec.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# shellcheck disable=SC2286
+
 Describe 'kdumpctl'
 	Include ./kdumpctl
 

--- a/tests/scripts/build-image.sh
+++ b/tests/scripts/build-image.sh
@@ -54,4 +54,10 @@ img_add_qemu_cmd() {
 
 [ -e "$INST_SCRIPT" ] && source $INST_SCRIPT
 
+if [[ $USE_GUESTMOUNT ]]; then
+	# unmount the image before renaming it otherwise sync_guestunmount may falsely
+	# think that the image has been truely unmounted
+	sync_guestunmount $OUTPUT_IMAGE.building ${MNTS[$OUTPUT_IMAGE.building]}
+fi
+
 mv $OUTPUT_IMAGE.building $OUTPUT_IMAGE

--- a/tests/scripts/test-lib.sh
+++ b/tests/scripts/test-lib.sh
@@ -86,10 +86,16 @@ build_test_image() {
 }
 
 run_test_sync() {
-	local qemu_cmd=$(get_test_qemu_cmd $1)
+	local qemu_cmd=$(get_test_qemu_cmd $1) _timeout
+
+	if [[ $KUMP_TEST_QEMU_TIMEOUT ]]; then
+		_timeout=$KUMP_TEST_QEMU_TIMEOUT
+	else
+		_timeout=10m
+	fi
 
 	if [ -n "$qemu_cmd" ]; then
-		timeout --foreground 10m $BASEDIR/run-qemu $(get_test_qemu_cmd $1)
+		timeout --foreground $_timeout $BASEDIR/run-qemu $(get_test_qemu_cmd $1)
 	else
 		echo "error: test qemu command line is not configured" > /dev/stderr
 		return 1

--- a/tools/run-integration-tests.sh
+++ b/tools/run-integration-tests.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -ex
+
+[[ -d ${0%/*} ]] && cd "${0%/*}"/../
+
+source /etc/os-release
+
+cd tests
+
+# fedpkg fetch sources based on branch.f$VERSION_ID.remote
+if ! grep -q fedora_src <(git remote show); then
+	git remote add fedora_src https://src.fedoraproject.org/rpms/kexec-tools.git
+fi
+git config --add branch.f$VERSION_ID.remote fedora_src
+
+can_we_use_qemu_nbd()
+{
+	_tmp_img=/tmp/test.qcow2
+
+	(sudo -v && sudo modprobe nbd \
+		&& qemu-img create -fqcow2 $_tmp_img 10m \
+		&& qemu-nbd -c /dev/nbd0 $_tmp_img && sudo qemu-nbd -d /dev/nbd0 && rm $_tmp_img) &> /dev/null
+}
+
+if ! can_we_use_qemu_nbd; then
+	USE_GUESTMOUNT=1
+fi
+
+KUMP_TEST_QEMU_TIMEOUT=20m USE_GUESTMOUNT=$USE_GUESTMOUNT BASE_IMAGE=/usr/share/cloud_images/Fedora-Cloud-Base-36-1.5.x86_64.qcow2 RELEASE=$VERSION_ID make test-run


### PR DESCRIPTION
Currently, kexec-tools parses legacy ifcfg-* configuration files or
NetworkManager .nmconnection connection profiles to build up dracut
command line parameters like ip=. Then dracut parses these parameters and
runs nm-initrd-generator to generate NetworkManager connection profiles.
Taking a bonding network as an example, nm-initrd-generator generates two
connections as follows,
  $ /usr/libexec/nm-initrd-generator -s -- bootdev=mybond0 rd.neednet kdumpnic=mybond0 bond=mybond0:kdump-eth0
  
  *** Connection 'mybond0' ***
  
  [connection]
  id=mybond0
  uuid=ed87d02b-dd44-4f0e-8b11-37db7e89bb48
  interface-name=mybond0
  
  [ipv4]
  dhcp-timeout=90
  ...
  
  *** Connection 'kdump-eth0' ***
  
  [connection]
  id=kdump-eth0
  uuid=ed6a7448-b5f8-4f8a-b718-3e24ea1c924b
  type=ethernet
  interface-name=kdump-eth0
  master=ed87d02b-dd44-4f0e-8b11-37db7e89bb48
  slave-type=bond
  wait-device-timeout=60000
		...
  

Later in kdump initrd, dracut starts NetworkManager to activate these
profiles to bring up the network connections. This way of setting up
kdump network is tedious, error-prone and unnecessary. A better way is
to directly copy the needed connection profiles which have been used to
successfully to establish network connections to kdump initrd. 

This patch set reuses NetworkManager connection profiles to setup kdump
network. Dumping vmcore to a remote network file system e.g. NFS
requires established network connections, this patch set asks nm-online
to wait for the network connections to be truly established. This fixes
a type of problems that vmcore dumping fails because network isn't ready
and there is no need to use timeout workarounds like
rd.net.timeout.carrier/dhcp/route anymore. 

Kdump has limited reserved memory. This patch set also eliminates
unnecessary network memory consumption. A machine could have multiple
network drivers and a network driver may manage multiple network
interfaces. It's possible kdump may only need one network interface. In
this case, there is no need to install unneeded network drivers or bring
up unneeded network interface.

There are cases where a network interface may have a different name in
the kdump kernel. Currently, kexec-tools creates udev rules to rename
NIC to have a consistent name. With the new approach, we can simply ask
NM to match the connection profile by MAC address instead.

Here are the bug list that addressed by this patch set,
 - Bug 1962421 - [RHEL-9]"eth0: Failed to rename network interface 3 from 'eth0' to 'kdump-eth0': File exists"
 - Bug 2064708 - kdump: mkdumprd: failed to make kdump initrd for bridge network on z15 z/vm
 - bugs related to OOM caused by network driver
   - Bug 1950282 - shutdown those unneeded network interfaces to save memory for kdump
	 - Bug 1958587 - the kdump initramfs includes unnecessary NIC drivers for SSH/NFS dumping target
   - Bug 1890021 - be2net is using too much memory during kdump
   - Bug 1662202 - [RHEL-8.1] aarch64: hpe-apache crashkernel OOM when dump to network targe
 - vmcore dumping fails because network isn't ready
	 - Bug 1817321 – [RHEL-8.2] SSH kdump failed: dracut-initqueue[449]: Warning: No carrier detected on interface
     SSH kdump 10x - Failed 3 times on RHEL-8.2 RC
   - Bug 2035451 – RHEL9.0 - [P9] Triggering fadump over NFS from Glacier Park IB Ports (mlx5_core) driver adapter is causing LPAR to shutdown() [MOFED4.9] (dracut)
   - Bug 1645976 – [RHEL-8.0][x86_64] NFS dump fails to mount nfs-filesystem on particular pairs of machines 


v3:
 - fix occasional vmcore dumping failures on certain machines (Thanks to Xiaoyin)
   - Dumping via IPv4, but only IPv6 is ready
   - Dumping via IPv6, but only IPv4 is ready
 - ask nm-online to wait for connectivity to be truly established 
   - With this change, no need for wait-device-timeout=60000
   - customers don't need workaround like rd.carrier.timeout
 - only process nmconnection profiles needed by kdump
 - install znet in the end (install_net could be called multiple times)
 - squash clean up patch with previous patch to avoid causing trouble
   for git bisection
 - typos fix and capitalize the first word of commit subjecat 
 - redirect the warnings (false postives) of "nmcli connection modify" to ddebug

v2:
- removes useless cat which also avoids SC2013
- fix code format issue and shellcheck warning
- squash four commits "set up kdump network {bridge,vlan,bridge,team} by directly
- copying NM connection profile to initrd" to switch to the new approach
  all at once to avoid confusion and causing trouble for git bisection
- fix several issues found by Philipp
  - add missing reference
  - use an array instead of supress shellchek SC2086 warning
  - use $_netifs instead of $_netif_allowlist to intruct NM to only
    manage specified NICs
  - multiple typos
	- use nmcli --get-values to get type first then construct MAC field name
  - get rid of the extra indentation
  - s/uniq_name/unique_name/

v1: 
- refactor complex kdump_copy_nmconnection_file [Philipp]
- clean up temporary file in a trap [Philipp]
- improve sed [Philipp]
- use long name consistently [Philipp]
- use nmcli -t, --terse option to suppress printing of the header [Philipp]
- don't pass kdumpip to initrd [Kairui]
- address the case where kdump_install_net is called multiple times like
  fence kdump
  - call kdump_install_nm_netif_allowlist after all kdump_install_net
		  calls have been finished
- ask NM to match a connection profile to a physical NIC by MAC address
- stop treating vlan specially when its parent interface is a physical NIC
- don't add unused NIC drivers to kdump initrd 
- fix the error of "/etc/NetworkManager/system-connections/*.nmconnection" not exist
  grep: /etc/NetworkManager/system-connections/*.nmconnection: No such file or directory
- redirect the messages of nmcli to ddebug
- use "grep -s" to get rid of the following warnings
  grep: /var/tmp/dracut.6tqUm0/initramfs//etc/NetworkManager/system-connections/*.nmconnection: No such file or directory
  grep: /etc/sysconfig/network-scripts/ifcfg-*: No such file or directory
  grep: /etc/NetworkManager/system-connections/*.nmconnection: No such file or directory