### PR TITLE
kdumpctl: make the kdump.log root-readable-only

### DIFF
--- a/kdumpctl
+++ b/kdumpctl
@@ -691,6 +691,7 @@ load_kdump()
 	# and release it.
 	exec 12>&2
 	exec 2>> $KDUMP_LOG_PATH/kdump.log
+	chmod 600 $KDUMP_LOG_PATH/kdump.log
 	PS4='+ $(date "+%Y-%m-%d %H:%M:%S") ${BASH_SOURCE}@${LINENO}: '
 	set -x
 


### PR DESCRIPTION
Decrease the risk that of leaking information that could potentially
be used to exploit the crash further (think location of keys).

Signed-off-by: Lichen Liu <lichliu@redhat.com>
Acked-by: Coiby Xu <coxu@redhat.com>