### PR TITLE
mkdumprd: Improve error messages on non-existing NFS target directories

### DIFF
--- a/mkdumprd
+++ b/mkdumprd
@@ -243,7 +243,7 @@ check_user_configured_target()
 
 	# For user configured target, use $SAVE_PATH as the dump path within the target
 	if [[ ! -d "$_mnt/$SAVE_PATH" ]]; then
-		perror_exit "Dump path \"$_mnt/$SAVE_PATH\" does not exist in dump target \"$_target\""
+		perror_exit "Dump path \"$SAVE_PATH\" does not exist in dump target \"$_target\""
 	fi
 
 	check_size fs "$_target"


### PR DESCRIPTION
When kdump is configured with a NFS location, and the remote directory does not exist, kdump.service fails with a confusing error message.

    kdumpctl[2172]: kdump: Dump path "/tmp/mkdumprd.ftWhOF/target/dumps"
    does not exist in dump target "10.111.113.2:/srv/kdump"

We just need to print the remote directory "dumps" in such case, because "/tmp/mkdumprd.ftWhOF/target" is the local temporary mount point.

Signed-off-by: Lichen Liu <lichliu@redhat.com>