### PR TITLE
fadump: avoid non-debug kernel use for fadump case

### DIFF
--- a/kdump-lib.sh
+++ b/kdump-lib.sh
@@ -682,7 +682,13 @@ prepare_kdump_bootinfo()
 
 	if [[ -z $KDUMP_KERNELVER ]]; then
 		KDUMP_KERNELVER=$(uname -r)
-		nondebug_kernelver=$(sed -n -e 's/\(.*\)+debug$/\1/p' <<< "$KDUMP_KERNELVER")
+
+		# Fadump uses the regular bootloader, unlike kdump. So, use the same version
+		# for default kernel and capture kernel unless specified explicitly with
+		# KDUMP_KERNELVER option.
+		if ! is_fadump_capable; then
+			nondebug_kernelver=$(sed -n -e 's/\(.*\)+debug$/\1/p' <<< "$KDUMP_KERNELVER")
+		fi
 	fi
 
 	# Use nondebug kernel if possible, because debug kernel will consume more memory and may oom.


### PR DESCRIPTION
Since commit c5bdd2d8f195 ("kdump-lib: use non-debug kernels first"), non-debug kernel is preferred, over the debug variant, as dump capture kernel to reduce memory consumption. This works alright for kdump as the capture kernel is loaded using kexec.

In case of fadump, regular boot loader is used to load the capture kernel. So, the default kernel needs to be used as capture kernel as well. But with commit c5bdd2d8f195, initrd of a different kernel is made dump capture capable, breaking fadump's ability to capture dump properly. Fix this by sticking with the debug variant in case of fadump.

Fixes: c5bdd2d8f195 ("kdump-lib: use non-debug kernels first")

Signed-off-by: Hari Bathini <hbathini@linux.ibm.com>
Acked-by: Lichen Liu <lichliu@redhat.com>
Acked-by: Coiby Xu <coxu@redhat.com>