### PR TITLE
virtiofs support for kexec-tools

### DIFF
--- a/dracut-kdump.sh
+++ b/dracut-kdump.sh
@@ -526,7 +526,7 @@ read_kdump_confs()
 				DUMP_INSTRUCTION="dump_fs $config_val"
 			fi
 			;;
-		ext[234] | xfs | btrfs | minix | nfs)
+		ext[234] | xfs | btrfs | minix | nfs | virtiofs)
 			config_val=$(get_mntpoint_from_target "$config_val")
 			DUMP_INSTRUCTION="dump_fs $config_val"
 			;;

--- a/dracut-module-setup.sh
+++ b/dracut-module-setup.sh
@@ -676,7 +676,7 @@ kdump_install_conf() {
                 _pdev=$(persistent_policy="by-id" kdump_get_persistent_dev "$_val")
                 sed -i -e "s#^${_opt}[[:space:]]\+$_val#$_opt $_pdev#" "${initdir}/tmp/$$-kdump.conf"
                 ;;
-            ext[234] | xfs | btrfs | minix)
+            ext[234] | xfs | btrfs | minix | virtiofs)
                 _pdev=$(kdump_get_persistent_dev "$_val")
                 sed -i -e "s#^${_opt}[[:space:]]\+$_val#$_opt $_pdev#" "${initdir}/tmp/$$-kdump.conf"
                 ;;

--- a/kdump-lib-initramfs.sh
+++ b/kdump-lib-initramfs.sh
@@ -57,6 +57,11 @@ is_fs_type_nfs()
 	[ "$1" = "nfs" ] || [ "$1" = "nfs4" ]
 }
 
+is_fs_type_virtiofs()
+{
+	[ "$1" = "virtiofs" ]
+}
+
 # If $1 contains dracut_args "--mount", return <filesystem type>
 get_dracut_args_fstype()
 {
@@ -112,6 +117,23 @@ is_raw_dump_target()
 	[ -n "$(kdump_get_conf_val raw)" ]
 }
 
+is_virtiofs_dump_target()
+{
+	if [ -n "$(kdump_get_conf_val virtiofs)" ]; then
+		return 0
+	fi
+
+	if is_fs_type_virtiofs "$(get_dracut_args_fstype "$(kdump_get_conf_val dracut_args)")"; then
+		return 0
+	fi
+
+	if is_fs_type_virtiofs "$(get_fs_type_from_target "$(get_target_from_path "$(get_save_path)")")"; then
+		return 0
+	fi
+
+	return 1
+}
+
 is_nfs_dump_target()
 {
 	if [ -n "$(kdump_get_conf_val nfs)" ]; then
@@ -131,5 +153,5 @@ is_nfs_dump_target()
 
 is_fs_dump_target()
 {
-	[ -n "$(kdump_get_conf_val "ext[234]\|xfs\|btrfs\|minix")" ]
+	[ -n "$(kdump_get_conf_val "ext[234]\|xfs\|btrfs\|minix\|virtiofs")" ]
 }

--- a/kdump-lib.sh
+++ b/kdump-lib.sh
@@ -83,35 +83,31 @@ to_dev_name()
 
 is_user_configured_dump_target()
 {
-	[[ $(kdump_get_conf_val "ext[234]\|xfs\|btrfs\|minix\|raw\|nfs\|ssh") ]] || is_mount_in_dracut_args
-}
-
-get_user_configured_dump_disk()
-{
-	local _target
-
-	_target=$(kdump_get_conf_val "ext[234]\|xfs\|btrfs\|minix\|raw")
-	[[ -n $_target ]] && echo "$_target" && return
-
-	_target=$(get_dracut_args_target "$(kdump_get_conf_val "dracut_args")")
-	[[ -b $_target ]] && echo "$_target"
+	[[ $(kdump_get_conf_val "ext[234]\|xfs\|btrfs\|minix\|raw\|nfs\|ssh\|virtiofs") ]] || is_mount_in_dracut_args
 }
 
 get_block_dump_target()
 {
-	local _target _path
+	local _target _fstype
 
 	if is_ssh_dump_target || is_nfs_dump_target; then
 		return
 	fi
 
-	_target=$(get_user_configured_dump_disk)
+	_target=$(kdump_get_conf_val "ext[234]\|xfs\|btrfs\|minix\|raw\|virtiofs")
 	[[ -n $_target ]] && to_dev_name "$_target" && return
 
-	# Get block device name from local save path
-	_path=$(get_save_path)
-	_target=$(get_target_from_path "$_path")
-	[[ -b $_target ]] && to_dev_name "$_target"
+	_target=$(get_dracut_args_target "$(kdump_get_conf_val "dracut_args")")
+	[[ -b $_target ]] && to_dev_name "$_target" && return
+
+	_fstype=$(get_dracut_args_fstype "$(kdump_get_conf_val "dracut_args")")
+	is_fs_type_virtiofs "$_fstype" && echo "$_target" && return
+
+	_target=$(get_target_from_path "$(get_save_path)")
+	[[ -b $_target ]] && to_dev_name "$_target" && return
+
+	_fstype=$(get_fs_type_from_target "$_target")
+	is_fs_type_virtiofs "$_fstype" && echo "$_target" && return
 }
 
 is_dump_to_rootfs()
@@ -127,6 +123,7 @@ get_failure_action_target()
 		# Get rootfs device name
 		_target=$(get_root_fs_device)
 		[[ -b $_target ]] && to_dev_name "$_target" && return
+		is_fs_type_virtiofs "$(get_fs_type_from_target "$_target")" && echo "$_target" && return
 		# Then, must be nfs root
 		echo "nfs"
 	fi

--- a/kdump.conf
+++ b/kdump.conf
@@ -43,6 +43,7 @@
 #             It's recommended to use persistent device names
 #             such as /dev/vg/<devname>.
 #             Otherwise it's suggested to use label or uuid.
+#             Supported fs types: ext[234], xfs, btrfs, minix, virtiofs
 #
 # path <path>
 #           - "path" represents the file system path in which vmcore
@@ -171,6 +172,7 @@
 #ext4 /dev/vg/lv_kdump
 #ext4 LABEL=/boot
 #ext4 UUID=03138356-5e61-4ab3-b58e-27507ac41937
+#virtiofs myfs
 #nfs my.server.com:/export/tmp
 #nfs [2001:db8::1:2:3:4]:/export/tmp
 #ssh user@my.server.com

--- a/kdumpctl
+++ b/kdumpctl
@@ -239,7 +239,7 @@ parse_config()
 			_set_config _fstype "$config_opt" || return 1
 			config_opt=_target
 			;;
-		ext[234] | minix | btrfs | xfs | nfs | ssh)
+		ext[234] | minix | btrfs | xfs | nfs | ssh | virtiofs)
 			_set_config _fstype "$config_opt" || return 1
 			config_opt=_target
 			;;
@@ -478,8 +478,8 @@ check_fs_modified()
 	fi
 
 	# No need to check in case of raw target.
-	# Currently we do not check also if ssh/nfs target is specified
-	if is_ssh_dump_target || is_nfs_dump_target || is_raw_dump_target; then
+	# Currently we do not check also if ssh/nfs/virtiofs target is specified
+	if is_ssh_dump_target || is_nfs_dump_target || is_raw_dump_target || is_virtiofs_dump_target; then
 		return 0
 	fi
 

--- a/mkdumprd
+++ b/mkdumprd
@@ -392,7 +392,7 @@ while read -r config_opt config_val; do
 	extra_modules)
 		extra_modules="$extra_modules $config_val"
 		;;
-	ext[234] | xfs | btrfs | minix | nfs)
+	ext[234] | xfs | btrfs | minix | nfs | virtiofs)
 		check_user_configured_target "$config_val" "$config_opt"
 		add_mount "$config_val" "$config_opt"
 		;;


### PR DESCRIPTION
This patch add virtiofs support for kexec-tools by introducing a new option for /etc/kdump.conf:

virtiofs myfs

Where myfs is a variable tag name specified in qemu cmdline "-device vhost-user-fs-pci,tag=myfs".

The patch covers the following cases:
1) Dumping VM's vmcore to a virtiofs shared directory; 2) When the VM's rootfs is a virtiofs shared directory and dumping the
   VM's vmcore to its subdirectory, such as /var/crash;
3) The combination of case 1 & 2: The VM's rootfs is a virtiofs shared
   directory and dumping the VM's vmcore to another virtiofs shared
   directory.

Case 2 & 3 need dracut >= 057, otherwise VM cannot boot from virtiofs shared rootfs. But it is not the issue of kexec-tools.

Reviewed-by: Philipp Rudo <prudo@redhat.com>
Signed-off-by: Tao Liu <ltao@redhat.com>