### PR TITLE
Fix the sync issue for dump_fs

### DIFF
--- a/dracut-kdump.sh
+++ b/dracut-kdump.sh
@@ -174,9 +174,15 @@ dump_fs()
 	$CORE_COLLECTOR /proc/vmcore "$_dump_fs_path/vmcore-incomplete"
 	_dump_exitcode=$?
 	if [ $_dump_exitcode -eq 0 ]; then
-		mv "$_dump_fs_path/vmcore-incomplete" "$_dump_fs_path/vmcore"
-		sync
-		dinfo "saving vmcore complete"
+		sync -f "$_dump_fs_path/vmcore-incomplete"
+		_sync_exitcode=$?
+		if [ $_sync_exitcode -eq 0 ]; then
+			mv "$_dump_fs_path/vmcore-incomplete" "$_dump_fs_path/vmcore"
+			dinfo "saving vmcore complete"
+		else
+			derror "sync vmcore failed, exitcode:$_sync_exitcode"
+			return 1
+		fi
 	else
 		derror "saving vmcore failed, exitcode:$_dump_exitcode"
 		return 1


### PR DESCRIPTION
Previously the sync for dump_fs is problematic, it always return success according to man 2 sync. So it cannot detect the error of the dump target is full and not all of vmcore data been written back the disk, which will leave the vmcore imcomplete and report misleading log as "saving vmcore complete".

In this patch, we will use "sync -f vmcore" instead, which will return error if syncfs on the dump target fails. In this way, vmcore sync related failures, such as autoextend of lvm2 thinpool fails, can be detected and handled properly.

Signed-off-by: Tao Liu <ltao@redhat.com>