### PR TITLE
Add lvm2 thin provision support for  kdump

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,53 @@
+name: kexec-tools tests
+
+on: pull_request
+
+jobs:
+  format-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: wget https://github.com/mvdan/sh/releases/download/v3.4.3/shfmt_v3.4.3_linux_amd64 -O /usr/local/bin/shfmt && chmod +x /usr/local/bin/shfmt
+      - run: shfmt -d *.sh kdumpctl mk*dumprd
+
+  static-analysis:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: curl -L -O https://github.com/koalaman/shellcheck/releases/download/v0.8.0/shellcheck-v0.8.0.linux.x86_64.tar.xz && tar -xJf shellcheck-v0.8.0.linux.x86_64.tar.xz
+      # Currently, for kexec-tools, there is need for shellcheck to require
+      # the sourced file to give correct warnings about the checked file
+      - run: shellcheck-v0.8.0/shellcheck --exclude=1090,1091 *.sh spec/*.sh kdumpctl mk*dumprd
+
+  unit-tests:
+    runs-on: ubuntu-latest
+    container: docker.io/fedora:latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: sudo dnf install -y make dracut grubby hostname
+      - run: curl -L -O https://github.com/shellspec/shellspec/archive/latest.tar.gz && tar -xzf latest.tar.gz
+      - run: cd shellspec-latest && sudo make install
+      - run: shellspec
+
+  integration-tests:
+        runs-on: self-hosted
+        timeout-minutes: 45
+        concurrency:
+            group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.container }}-${{ matrix.test }}
+            cancel-in-progress: true
+        strategy:
+            matrix:
+                container: [
+                        "fedora:36",
+                ]
+            fail-fast: false
+        container:
+            image: ghcr.io/coiby/${{ matrix.container }}
+            options: "--privileged -v /dev:/dev -v /lib/modules:/lib/modules:ro"
+        steps:
+            -   name: "Checkout Repository"
+                uses: actions/checkout@v2
+                with:
+                    fetch-depth: 0
+            -   name: "${{ matrix.container }} kdump tests"
+                run: bash ./tools/run-integration-tests.sh

--- a/dracut-early-kdump-module-setup.sh
+++ b/dracut-early-kdump-module-setup.sh
@@ -23,7 +23,7 @@ prepare_kernel_initrd() {
 
     prepare_kdump_bootinfo
 
-    # $kernel is a variable from dracut
+    # shellcheck disable=SC2154 # $kernel is a variable from dracut
     if [[ $KDUMP_KERNELVER != "$kernel" ]]; then
         dwarn "Using kernel version '$KDUMP_KERNELVER' for early kdump," \
             "but the initramfs is generated for kernel version '$kernel'"
@@ -54,6 +54,7 @@ install() {
     inst_script "/lib/kdump/kdump-lib.sh" "/lib/kdump-lib.sh"
     inst_script "/lib/kdump/kdump-lib-initramfs.sh" "/lib/kdump/kdump-lib-initramfs.sh"
     inst_script "/lib/kdump/kdump-logger.sh" "/lib/kdump-logger.sh"
+    # shellcheck disable=SC2154 # $moddir is a variable from dracut
     inst_hook cmdline 00 "$moddir/early-kdump.sh"
     inst_binary "$KDUMP_KERNEL"
     inst_binary "$KDUMP_INITRD"
@@ -61,5 +62,6 @@ install() {
     ln_r "$KDUMP_KERNEL" "/boot/kernel-earlykdump"
     ln_r "$KDUMP_INITRD" "/boot/initramfs-earlykdump"
 
+    # shellcheck disable=SC2154 # $initdir is a variable from dracut
     chmod -x "${initdir}/$KDUMP_KERNEL"
 }

--- a/dracut-early-kdump.sh
+++ b/dracut-early-kdump.sh
@@ -6,7 +6,6 @@ standard_kexec_args="-p"
 EARLY_KDUMP_INITRD=""
 EARLY_KDUMP_KERNEL=""
 EARLY_KDUMP_CMDLINE=""
-EARLY_KDUMP_KERNELVER=""
 EARLY_KEXEC_ARGS=""
 
 . /etc/sysconfig/kdump
@@ -57,7 +56,7 @@ early_kdump_load()
 	ddebug "earlykdump: $KEXEC ${EARLY_KEXEC_ARGS} $standard_kexec_args \
 	--command-line=$EARLY_KDUMP_CMDLINE --initrd=$EARLY_KDUMP_INITRD \
 	$EARLY_KDUMP_KERNEL"
-
+	# shellcheck disable=SC2086 # $EARLY_KEXEC_ARGS depends on word splitting
 	if $KEXEC $EARLY_KEXEC_ARGS $standard_kexec_args \
 		--command-line="$EARLY_KDUMP_CMDLINE" \
 		--initrd=$EARLY_KDUMP_INITRD $EARLY_KDUMP_KERNEL; then

--- a/dracut-early-kdump.sh
+++ b/dracut-early-kdump.sh
@@ -16,69 +16,69 @@ EARLY_KEXEC_ARGS=""
 
 # initiate the kdump logger
 if ! dlog_init; then
-        echo "failed to initiate the kdump logger."
-        exit 1
+	echo "failed to initiate the kdump logger."
+	exit 1
 fi
 
 prepare_parameters()
 {
-    EARLY_KDUMP_CMDLINE=$(prepare_cmdline "${KDUMP_COMMANDLINE}" "${KDUMP_COMMANDLINE_REMOVE}" "${KDUMP_COMMANDLINE_APPEND}")
-    EARLY_KDUMP_KERNEL="/boot/kernel-earlykdump"
-    EARLY_KDUMP_INITRD="/boot/initramfs-earlykdump"
+	EARLY_KDUMP_CMDLINE=$(prepare_cmdline "${KDUMP_COMMANDLINE}" "${KDUMP_COMMANDLINE_REMOVE}" "${KDUMP_COMMANDLINE_APPEND}")
+	EARLY_KDUMP_KERNEL="/boot/kernel-earlykdump"
+	EARLY_KDUMP_INITRD="/boot/initramfs-earlykdump"
 }
 
 early_kdump_load()
 {
-    if ! check_kdump_feasibility; then
-        return 1
-    fi
+	if ! check_kdump_feasibility; then
+		return 1
+	fi
 
-    if is_fadump_capable; then
-        dwarn "WARNING: early kdump doesn't support fadump."
-        return 1
-    fi
+	if is_fadump_capable; then
+		dwarn "WARNING: early kdump doesn't support fadump."
+		return 1
+	fi
 
-    if check_current_kdump_status; then
-        return 1
-    fi
+	if check_current_kdump_status; then
+		return 1
+	fi
 
-    prepare_parameters
+	prepare_parameters
 
-    EARLY_KEXEC_ARGS=$(prepare_kexec_args "${KEXEC_ARGS}")
+	EARLY_KEXEC_ARGS=$(prepare_kexec_args "${KEXEC_ARGS}")
 
-    if is_secure_boot_enforced; then
-        dinfo "Secure Boot is enabled. Using kexec file based syscall."
-        EARLY_KEXEC_ARGS="$EARLY_KEXEC_ARGS -s"
-    fi
+	if is_secure_boot_enforced; then
+		dinfo "Secure Boot is enabled. Using kexec file based syscall."
+		EARLY_KEXEC_ARGS="$EARLY_KEXEC_ARGS -s"
+	fi
 
-    # Here, only output the messages, but do not save these messages
-    # to a file because the target disk may not be mounted yet, the
-    # earlykdump is too early.
-    ddebug "earlykdump: $KEXEC ${EARLY_KEXEC_ARGS} $standard_kexec_args \
+	# Here, only output the messages, but do not save these messages
+	# to a file because the target disk may not be mounted yet, the
+	# earlykdump is too early.
+	ddebug "earlykdump: $KEXEC ${EARLY_KEXEC_ARGS} $standard_kexec_args \
 	--command-line=$EARLY_KDUMP_CMDLINE --initrd=$EARLY_KDUMP_INITRD \
 	$EARLY_KDUMP_KERNEL"
 
-    if $KEXEC $EARLY_KEXEC_ARGS $standard_kexec_args \
-        --command-line="$EARLY_KDUMP_CMDLINE" \
-        --initrd=$EARLY_KDUMP_INITRD $EARLY_KDUMP_KERNEL; then
-        dinfo "kexec: loaded early-kdump kernel"
-        return 0
-    else
-        derror "kexec: failed to load early-kdump kernel"
-        return 1
-    fi
+	if $KEXEC $EARLY_KEXEC_ARGS $standard_kexec_args \
+		--command-line="$EARLY_KDUMP_CMDLINE" \
+		--initrd=$EARLY_KDUMP_INITRD $EARLY_KDUMP_KERNEL; then
+		dinfo "kexec: loaded early-kdump kernel"
+		return 0
+	else
+		derror "kexec: failed to load early-kdump kernel"
+		return 1
+	fi
 }
 
 set_early_kdump()
 {
-    if getargbool 0 rd.earlykdump; then
-        dinfo "early-kdump is enabled."
-        early_kdump_load
-    else
-        dinfo "early-kdump is disabled."
-    fi
+	if getargbool 0 rd.earlykdump; then
+		dinfo "early-kdump is enabled."
+		early_kdump_load
+	else
+		dinfo "early-kdump is disabled."
+	fi
 
-    return 0
+	return 0
 }
 
 set_early_kdump

--- a/dracut-fadump-init-fadump.sh
+++ b/dracut-fadump-init-fadump.sh
@@ -37,7 +37,7 @@ if [ -f /proc/device-tree/rtas/ibm,kernel-dump ] || [ -f /proc/device-tree/ibm,o
 				case $mp in
 				/oldroot/*) umount -d "$mp" && loop=1 ;;
 				esac
-			done </proc/mounts
+			done < /proc/mounts
 		done
 		umount -d -l oldroot
 

--- a/dracut-fadump-init-fadump.sh
+++ b/dracut-fadump-init-fadump.sh
@@ -15,9 +15,7 @@ if [ -f /proc/device-tree/rtas/ibm,kernel-dump ] || [ -f /proc/device-tree/ibm,o
 	mount -t ramfs ramfs /newroot
 
 	if [ $ROOTFS_IS_RAMFS ]; then
-		for FILE in $(ls -A /fadumproot/); do
-			mv /fadumproot/$FILE /newroot/
-		done
+		find /fadumproot/ -mindepth 1 -maxdepth 1 -exec mv {} /newroot/ \;
 		exec switch_root /newroot /init
 	else
 		mkdir /newroot/sys /newroot/proc /newroot/dev /newroot/run /newroot/oldroot

--- a/dracut-fadump-module-setup.sh
+++ b/dracut-fadump-module-setup.sh
@@ -9,7 +9,9 @@ depends() {
 }
 
 install() {
+    # shellcheck disable=SC2154 # $initdir is a dracut variable
     mv -f "$initdir/init" "$initdir/init.dracut"
+    # shellcheck disable=SC2154 # $moddir is a dracut variable
     inst_script "$moddir/init-fadump.sh" /init
     chmod a+x "$initdir/init"
 

--- a/dracut-kdump.sh
+++ b/dracut-kdump.sh
@@ -301,12 +301,12 @@ do_failure_action()
 do_final_action()
 {
 	dinfo "Executing final action $FINAL_ACTION"
-	eval $FINAL_ACTION
+	eval "$FINAL_ACTION"
 }
 
 do_dump()
 {
-	eval $DUMP_INSTRUCTION
+	eval "$DUMP_INSTRUCTION"
 	_ret=$?
 
 	if [ $_ret -ne 0 ]; then
@@ -387,7 +387,7 @@ dump_raw()
 dump_ssh()
 {
 	_ret=0
-	_ssh_opt="-i $1 -o BatchMode=yes -o StrictHostKeyChecking=yes"
+	_ssh_opts="-i $1 -o BatchMode=yes -o StrictHostKeyChecking=yes"
 	_ssh_dir="$KDUMP_PATH/$HOST_IP-$DATEDIR"
 	if is_ipv6_address "$2"; then
 		_scp_address=${2%@*}@"[${2#*@}]"
@@ -398,29 +398,33 @@ dump_ssh()
 	dinfo "saving to $2:$_ssh_dir"
 
 	cat /var/lib/random-seed > /dev/urandom
-	ssh -q $_ssh_opt "$2" mkdir -p "$_ssh_dir" || return 1
+	# shellcheck disable=SC2086 # need to word-split $_ssh_opts
+	ssh -q $_ssh_opts "$2" mkdir -p "$_ssh_dir" || return 1
 
-	save_vmcore_dmesg_ssh "$DMESG_COLLECTOR" "$_ssh_dir" "$_ssh_opt" "$2"
+	save_vmcore_dmesg_ssh "$DMESG_COLLECTOR" "$_ssh_dir" "$_ssh_opts" "$2"
 
 	dinfo "saving vmcore"
 
 	KDUMP_LOG_DEST=$2:$_ssh_dir/
-	KDUMP_LOG_OP="scp -q $_ssh_opt '$KDUMP_LOG_FILE' '$_scp_address:$_ssh_dir/'"
+	KDUMP_LOG_OP="scp -q $_ssh_opts '$KDUMP_LOG_FILE' '$_scp_address:$_ssh_dir/'"
 
-	save_opalcore_ssh "$_ssh_dir" "$_ssh_opt" "$2" "$_scp_address"
+	save_opalcore_ssh "$_ssh_dir" "$_ssh_opts" "$2" "$_scp_address"
 
 	if [ "${CORE_COLLECTOR%%[[:blank:]]*}" = "scp" ]; then
-		scp -q $_ssh_opt /proc/vmcore "$_scp_address:$_ssh_dir/vmcore-incomplete"
+		# shellcheck disable=SC2086 # need to word-split $_ssh_opts
+		scp -q $_ssh_opts /proc/vmcore "$_scp_address:$_ssh_dir/vmcore-incomplete"
 		_ret=$?
 		_vmcore="vmcore"
 	else
-		$CORE_COLLECTOR /proc/vmcore | ssh $_ssh_opt "$2" "umask 0077 && dd bs=512 of='$_ssh_dir/vmcore-incomplete'"
+		# shellcheck disable=SC2086 # need to word-split $_ssh_opts
+		$CORE_COLLECTOR /proc/vmcore | ssh $_ssh_opts "$2" "umask 0077 && dd bs=512 of='$_ssh_dir/vmcore-incomplete'"
 		_ret=$?
 		_vmcore="vmcore.flat"
 	fi
 
 	if [ $_ret -eq 0 ]; then
-		ssh $_ssh_opt "$2" "mv '$_ssh_dir/vmcore-incomplete' '$_ssh_dir/$_vmcore'"
+		# shellcheck disable=SC2086 # need to word-split $_ssh_opts
+		ssh $_ssh_opts "$2" "mv '$_ssh_dir/vmcore-incomplete' '$_ssh_dir/$_vmcore'"
 		_ret=$?
 		if [ $_ret -ne 0 ]; then
 			derror "moving vmcore failed, exitcode:$_ret"
@@ -451,11 +455,13 @@ save_opalcore_ssh()
 
 	dinfo "saving opalcore:$OPALCORE to $3:$1"
 
+	# shellcheck disable=SC2086 # need to word-split $2
 	if ! scp $2 $OPALCORE "$4:$1/opalcore-incomplete"; then
 		derror "saving opalcore failed"
 		return 1
 	fi
 
+	# shellcheck disable=SC2086 # need to word-split $2
 	ssh $2 "$3" mv "$1/opalcore-incomplete" "$1/opalcore"
 	dinfo "saving opalcore complete"
 	return 0
@@ -468,6 +474,7 @@ save_opalcore_ssh()
 save_vmcore_dmesg_ssh()
 {
 	dinfo "saving vmcore-dmesg.txt to $4:$2"
+	# shellcheck disable=SC2086 # need to word-split $3
 	if $1 /proc/vmcore | ssh $3 "$4" "umask 0077 && dd of='$2/vmcore-dmesg-incomplete.txt'"; then
 		ssh -q $3 "$4" mv "$2/vmcore-dmesg-incomplete.txt" "$2/vmcore-dmesg.txt"
 		dinfo "saving vmcore-dmesg.txt complete"

--- a/dracut-kdump.sh
+++ b/dracut-kdump.sh
@@ -416,14 +416,14 @@ dump_ssh()
 		_ret=$?
 		_vmcore="vmcore"
 	else
-		# shellcheck disable=SC2086 # need to word-split $_ssh_opts
+		# shellcheck disable=SC2086,SC2029 # need to word-split $_ssh_opts and expand $_ssh_dir
 		$CORE_COLLECTOR /proc/vmcore | ssh $_ssh_opts "$2" "umask 0077 && dd bs=512 of='$_ssh_dir/vmcore-incomplete'"
 		_ret=$?
 		_vmcore="vmcore.flat"
 	fi
 
 	if [ $_ret -eq 0 ]; then
-		# shellcheck disable=SC2086 # need to word-split $_ssh_opts
+		# shellcheck disable=SC2086,SC2029 # need to word-split $_ssh_opts and expand $_ssh_dir
 		ssh $_ssh_opts "$2" "mv '$_ssh_dir/vmcore-incomplete' '$_ssh_dir/$_vmcore'"
 		_ret=$?
 		if [ $_ret -ne 0 ]; then
@@ -461,7 +461,7 @@ save_opalcore_ssh()
 		return 1
 	fi
 
-	# shellcheck disable=SC2086 # need to word-split $2
+	# shellcheck disable=SC2086,SC2029 # need to word-split $1 and expand $2
 	ssh $2 "$3" mv "$1/opalcore-incomplete" "$1/opalcore"
 	dinfo "saving opalcore complete"
 	return 0
@@ -474,7 +474,7 @@ save_opalcore_ssh()
 save_vmcore_dmesg_ssh()
 {
 	dinfo "saving vmcore-dmesg.txt to $4:$2"
-	# shellcheck disable=SC2086 # need to word-split $3
+	# shellcheck disable=SC2086,SC2029 # need to word-split $3 and expand $2
 	if $1 /proc/vmcore | ssh $3 "$4" "umask 0077 && dd of='$2/vmcore-dmesg-incomplete.txt'"; then
 		ssh -q $3 "$4" mv "$2/vmcore-dmesg-incomplete.txt" "$2/vmcore-dmesg.txt"
 		dinfo "saving vmcore-dmesg.txt complete"

--- a/dracut-module-setup.sh
+++ b/dracut-module-setup.sh
@@ -379,7 +379,7 @@ kdump_setup_bond() {
     local _netdev="$1"
     local _conpath="$2"
     local _dev _mac _slaves _kdumpdev _bondoptions
-    for _dev in $(cat "/sys/class/net/$_netdev/bonding/slaves"); do
+    for _dev in $(< "/sys/class/net/$_netdev/bonding/slaves"); do
         _mac=$(kdump_get_perm_addr "$_dev")
         _kdumpdev=$(kdump_setup_ifname "$_dev")
         echo -n " ifname=$_kdumpdev:$_mac" >> "${initdir}/etc/cmdline.d/42bond.conf"

--- a/dracut-module-setup.sh
+++ b/dracut-module-setup.sh
@@ -262,17 +262,17 @@ kdump_static_ip() {
         echo -n "${_srcaddr}::${_gateway}:${_netmask}::"
     fi
 
-    /sbin/ip $_ipv6_flag route show | grep -v default \
-        | grep ".*via.* $_netdev " | grep -v "^[[:space:]]*nexthop" \
-        | while read -r _route; do
-            _target=$(echo "$_route" | awk '{print $1}')
-            _nexthop=$(echo "$_route" | awk '{print $3}')
-            if [[ "x" != "x"$_ipv6_flag ]]; then
-                _target="[$_target]"
-                _nexthop="[$_nexthop]"
-            fi
-            echo "rd.route=$_target:$_nexthop:$kdumpnic"
-        done >> "${initdir}/etc/cmdline.d/45route-static.conf"
+    while read -r _route; do
+        _target=$(echo "$_route" | awk '{print $1}')
+        _nexthop=$(echo "$_route" | awk '{print $3}')
+        if [[ "x" != "x"$_ipv6_flag ]]; then
+            _target="[$_target]"
+            _nexthop="[$_nexthop]"
+        fi
+        echo "rd.route=$_target:$_nexthop:$kdumpnic"
+    done >> "${initdir}/etc/cmdline.d/45route-static.conf" \
+        < <(/sbin/ip $_ipv6_flag route show | grep -v default \
+            | grep ".*via.* $_netdev " | grep -v "^[[:space:]]*nexthop")
 
     kdump_handle_mulitpath_route "$_netdev" "$_srcaddr" "$kdumpnic"
 }

--- a/dracut-module-setup.sh
+++ b/dracut-module-setup.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 kdump_module_init() {
+    # shellcheck disable=SC2154 # $initdir is a dracut variable
     if ! [[ -d "${initdir}/tmp" ]]; then
         mkdir -p "${initdir}/tmp"
     fi
@@ -9,6 +10,7 @@ kdump_module_init() {
 }
 
 check() {
+    # shellcheck disable=SC2154 # $debug is a dracut variable
     [[ $debug ]] && set -x
     #kdumpctl sets this explicitly
     if [[ -z $IN_KDUMP ]] || [[ ! -f /etc/kdump.conf ]]; then
@@ -23,6 +25,7 @@ depends() {
     kdump_module_init
 
     add_opt_module() {
+        # shellcheck disable=SC2154 # $omit_dracutmodules is a dracut variable
         [[ " $omit_dracutmodules " != *\ $1\ * ]] && _dep="$_dep $1"
     }
 
@@ -851,7 +854,7 @@ kdump_check_iscsi_targets() {
         done
         [[ -d iscsi_session ]] && kdump_setup_iscsi_device "$PWD"
     )
-
+    # shellcheck disable=SC2154 # $hostonly and $mount_needs are from dracut
     [[ $hostonly ]] || [[ $mount_needs ]] && {
         for_each_host_dev_and_slaves_all kdump_check_setup_iscsi
     }
@@ -906,6 +909,7 @@ get_pcs_fence_kdump_nodes() {
     for node in ${nodelist}; do
         # convert $node from 'uname="nodeX"' to 'nodeX'
         eval "$node"
+        # shellcheck disable=SC2154 # $uname from dracut
         nodename="$uname"
         # Skip its own node name
         if is_localhost "$nodename"; then
@@ -1039,6 +1043,7 @@ install() {
         kdump_install_random_seed
     fi
     dracut_install -o /etc/adjtime /etc/localtime
+    # shellcheck disable=SC2154 # $uname and ${initdir} from dracut
     inst "$moddir/monitor_dd_progress" "/kdumpscripts/monitor_dd_progress"
     chmod +x "${initdir}/kdumpscripts/monitor_dd_progress"
     inst "/bin/dd" "/bin/dd"
@@ -1058,6 +1063,7 @@ install() {
     inst "/lib/kdump/kdump-lib-initramfs.sh" "/lib/kdump-lib-initramfs.sh"
     inst "/lib/kdump/kdump-logger.sh" "/lib/kdump-logger.sh"
     inst "$moddir/kdump.sh" "/usr/bin/kdump.sh"
+    # shellcheck disable=SC2154 # $systemdsystemunitdir from dracut
     inst "$moddir/kdump-capture.service" "$systemdsystemunitdir/kdump-capture.service"
     systemctl -q --root "$initdir" add-wants initrd.target kdump-capture.service
     # Replace existing emergency service and emergency target

--- a/dracut-module-setup.sh
+++ b/dracut-module-setup.sh
@@ -43,6 +43,14 @@ depends() {
         _dep="$_dep ssh-client"
     fi
 
+    if is_lvm2_thinp_dump_target; then
+        if dracut --list-modules | grep -q lvmthinpool-monitor; then
+            add_opt_module lvmthinpool-monitor
+        else
+            dwarning "Required lvmthinpool-monitor modules is missing! Please upgrade dracut >= 057."
+        fi
+    fi
+
     if [[ "$(uname -m)" == "s390x" ]]; then
         _dep="$_dep znet"
     fi

--- a/dracut-module-setup.sh
+++ b/dracut-module-setup.sh
@@ -1008,10 +1008,12 @@ kdump_install_systemd_conf() {
     # unneccessary memory consumption and make console output more useful.
     # Only do so for non fadump image.
     mkdir -p "${initdir}/etc/systemd/journald.conf.d"
-    echo "[Journal]" > "${initdir}/etc/systemd/journald.conf.d/kdump.conf"
-    echo "Storage=volatile" >> "${initdir}/etc/systemd/journald.conf.d/kdump.conf"
-    echo "ReadKMsg=no" >> "${initdir}/etc/systemd/journald.conf.d/kdump.conf"
-    echo "ForwardToConsole=yes" >> "${initdir}/etc/systemd/journald.conf.d/kdump.conf"
+    {
+        echo "[Journal]"
+        echo "Storage=volatile"
+        echo "ReadKMsg=no"
+        echo "ForwardToConsole=yes"
+    } > "${initdir}/etc/systemd/journald.conf.d/kdump.conf"
 }
 
 remove_cpu_online_rule() {

--- a/kdump-dep-generator.sh
+++ b/kdump-dep-generator.sh
@@ -11,13 +11,13 @@
 dest_dir="/tmp"
 
 if [ -n "$1" ]; then
-    dest_dir=$1
+	dest_dir=$1
 fi
 
 systemd_dir=/usr/lib/systemd/system
 kdump_wants=$dest_dir/kdump.service.wants
 
 if is_ssh_dump_target; then
-    mkdir -p $kdump_wants
-    ln -sf $systemd_dir/network-online.target $kdump_wants/
+	mkdir -p $kdump_wants
+	ln -sf $systemd_dir/network-online.target $kdump_wants/
 fi

--- a/kdump-dep-generator.sh
+++ b/kdump-dep-generator.sh
@@ -18,6 +18,6 @@ systemd_dir=/usr/lib/systemd/system
 kdump_wants=$dest_dir/kdump.service.wants
 
 if is_ssh_dump_target; then
-	mkdir -p $kdump_wants
-	ln -sf $systemd_dir/network-online.target $kdump_wants/
+	mkdir -p "$kdump_wants"
+	ln -sf $systemd_dir/network-online.target "$kdump_wants"/
 fi

--- a/kdump-lib-initramfs.sh
+++ b/kdump-lib-initramfs.sh
@@ -9,6 +9,7 @@ DEFAULT_SSHKEY="/root/.ssh/kdump_id_rsa"
 KDUMP_CONFIG_FILE="/etc/kdump.conf"
 # shellcheck disable=SC2034
 FENCE_KDUMP_SEND="/usr/libexec/fence_kdump_send"
+LVM_CONF="/etc/lvm/lvm.conf"
 
 # Read kdump config in well formated style
 kdump_read_conf()

--- a/kdump-lib-initramfs.sh
+++ b/kdump-lib-initramfs.sh
@@ -4,9 +4,10 @@
 # not be the default shell. Any code added must be POSIX compliant.
 
 DEFAULT_PATH="/var/crash/"
+# shellcheck disable=SC2034
 DEFAULT_SSHKEY="/root/.ssh/kdump_id_rsa"
 KDUMP_CONFIG_FILE="/etc/kdump.conf"
-FENCE_KDUMP_CONFIG_FILE="/etc/sysconfig/fence_kdump"
+# shellcheck disable=SC2034
 FENCE_KDUMP_SEND="/usr/libexec/fence_kdump_send"
 
 # Read kdump config in well formated style

--- a/kdump-lib-initramfs.sh
+++ b/kdump-lib-initramfs.sh
@@ -36,6 +36,7 @@ is_mounted()
 # $2: mount source type
 # $3: mount source
 # $4: extra args
+# shellcheck disable=SC2086 # $4 means extra args which nees to word-splitted
 get_mount_info()
 {
 	__kdump_mnt=$(findmnt -k -n -r -o "$1" "--$2" "$3" $4)
@@ -58,13 +59,13 @@ is_fs_type_nfs()
 # If $1 contains dracut_args "--mount", return <filesystem type>
 get_dracut_args_fstype()
 {
-	echo $1 | grep "\-\-mount" | sed "s/.*--mount .\(.*\)/\1/" | cut -d' ' -f3
+	echo "$1" | grep "\-\-mount" | sed "s/.*--mount .\(.*\)/\1/" | cut -d' ' -f3
 }
 
 # If $1 contains dracut_args "--mount", return <device>
 get_dracut_args_target()
 {
-	echo $1 | grep "\-\-mount" | sed "s/.*--mount .\(.*\)/\1/" | cut -d' ' -f1
+	echo "$1" | grep "\-\-mount" | sed "s/.*--mount .\(.*\)/\1/" | cut -d' ' -f1
 }
 
 get_save_path()

--- a/kdump-lib-initramfs.sh
+++ b/kdump-lib-initramfs.sh
@@ -133,3 +133,12 @@ is_fs_dump_target()
 {
 	[ -n "$(kdump_get_conf_val "ext[234]\|xfs\|btrfs\|minix")" ]
 }
+
+is_lvm2_thinp_device()
+{
+	_device_path=$1
+	_lvm2_thin_device=$(lvm lvs -S 'lv_layout=sparse && lv_layout=thin' \
+		--nosuffix --noheadings -o vg_name,lv_name "$_device_path" 2>/dev/null)
+
+	[ -n "$_lvm2_thin_device" ]
+}

--- a/kdump-lib.sh
+++ b/kdump-lib.sh
@@ -247,7 +247,7 @@ kdump_get_persistent_dev()
 		dev=$(blkid -L "${dev#LABEL=}")
 		;;
 	esac
-	echo $(get_persistent_dev "$dev")
+	get_persistent_dev "$dev"
 }
 
 is_ostree()

--- a/kdump-lib.sh
+++ b/kdump-lib.sh
@@ -1024,6 +1024,7 @@ get_kernel_size()
 		try_decompress '(\265/\375' xxx unzstd "$img" "$tmp"
 
 	# Finally check for uncompressed images or objects:
+	# shellcheck disable=SC2181 # to improve readability
 	[[ $? -eq 0 ]] && get_vmlinux_size "$tmp" && return 0
 
 	# Fallback to use iomem

--- a/kdump-lib.sh
+++ b/kdump-lib.sh
@@ -852,7 +852,7 @@ get_recommend_size()
 	while read -r -d , range; do
 		# need to use non-default IFS as double spaces are used as a
 		# single delimiter while commas aren't...
-		IFS=, read start start_unit end end_unit size <<< \
+		IFS=, read -r start start_unit end end_unit size <<< \
 			"$(echo "$range" | sed -n "s/\([0-9]\+\)\([GT]\?\)-\([0-9]*\)\([GT]\?\):\([0-9]\+[MG]\)/\1,\2,\3,\4,\5/p")"
 
 		# aka. 102400T
@@ -874,6 +874,7 @@ get_recommend_size()
 
 # get default crashkernel
 # $1 dump mode, if not specified, dump_mode will be judged by is_fadump_capable
+# shellcheck disable=SC2120 # kdumpctl will call this func with an argument
 kdump_get_arch_recommend_crashkernel()
 {
 	local _arch _ck_cmdline _dump_mode

--- a/kdump-lib.sh
+++ b/kdump-lib.sh
@@ -425,6 +425,7 @@ is_dracut_mod_omitted()
 {
 	local dracut_mod=$1
 
+	# shellcheck disable=SC2046 # a known issue https://github.com/koalaman/shellcheck/issues/2335
 	set -- $(kdump_get_conf_val dracut_args)
 	while [ $# -gt 0 ]; do
 		case $1 in

--- a/kdump-lib.sh
+++ b/kdump-lib.sh
@@ -174,7 +174,7 @@ get_bind_mount_source()
 	local _fsroot _src_nofsroot
 
 	_mnt=$(df "$1" | tail -1 | awk '{print $NF}')
-	_path=${1#$_mnt}
+	_path=${1#"$_mnt"}
 
 	_src=$(get_mount_info SOURCE target "$_mnt" -f)
 	_opt=$(get_mount_info OPTIONS target "$_mnt" -f)
@@ -191,7 +191,7 @@ get_bind_mount_source()
 		echo "$_mnt$_path" && return
 	fi
 
-	_fsroot=${_src#${_src_nofsroot}[}
+	_fsroot=${_src#"${_src_nofsroot}"[}
 	_fsroot=${_fsroot%]}
 	_mnt=$(get_mount_info TARGET source "$_src_nofsroot" -f)
 
@@ -200,7 +200,7 @@ get_bind_mount_source()
 		local _subvol
 		_subvol=${_opt#*subvol=}
 		_subvol=${_subvol%,*}
-		_fsroot=${_fsroot#$_subvol}
+		_fsroot=${_fsroot#"$_subvol"}
 	fi
 	echo "$_mnt$_fsroot$_path"
 }

--- a/kdump-lib.sh
+++ b/kdump-lib.sh
@@ -527,10 +527,10 @@ remove_cmdline_param()
 #
 get_bootcpu_apicid()
 {
-	awk '                                                       \
-        BEGIN { CPU = "-1"; }                                   \
-        $1=="processor" && $2==":"      { CPU = $NF; }          \
-        CPU=="0" && /^apicid/           { print $NF; }          \
+	awk '
+        BEGIN { CPU = "-1"; }
+        $1=="processor" && $2==":"      { CPU = $NF; }
+        CPU=="0" && /^apicid/           { print $NF; }
         ' \
 		/proc/cpuinfo
 }

--- a/kdump-lib.sh
+++ b/kdump-lib.sh
@@ -8,6 +8,8 @@ else
 	. /lib/kdump/kdump-lib-initramfs.sh
 fi
 
+# shellcheck disable=SC2034
+FENCE_KDUMP_CONFIG_FILE="/etc/sysconfig/fence_kdump"
 FADUMP_ENABLED_SYS_NODE="/sys/kernel/fadump_enabled"
 
 is_fadump_capable()
@@ -421,7 +423,7 @@ get_ifcfg_filename()
 # returns 1 otherwise
 is_dracut_mod_omitted()
 {
-	local dracut_args dracut_mod=$1
+	local dracut_mod=$1
 
 	set -- $(kdump_get_conf_val dracut_args)
 	while [ $# -gt 0 ]; do
@@ -736,8 +738,10 @@ prepare_kdump_bootinfo()
 	if [[ ! -w $KDUMP_BOOTDIR ]]; then
 		var_target_initrd_dir="/var/lib/kdump"
 		mkdir -p "$var_target_initrd_dir"
+		# shellcheck disable=SC2034 # KDUMP_INITRD is used by kdumpctl
 		KDUMP_INITRD="$var_target_initrd_dir/$kdump_initrd_base"
 	else
+		# shellcheck disable=SC2034 # KDUMP_INITRD is used by kdumpctl
 		KDUMP_INITRD="$KDUMP_BOOTDIR/$kdump_initrd_base"
 	fi
 }

--- a/kdump-lib.sh
+++ b/kdump-lib.sh
@@ -451,8 +451,7 @@ is_wdt_active()
 
 have_compression_in_dracut_args()
 {
-	[[ "$(kdump_get_conf_val dracut_args)" =~ \
-		(^|[[:space:]])--(gzip|bzip2|lzma|xz|lzo|lz4|zstd|no-compress|compress)([[:space:]]|$) ]]
+	[[ "$(kdump_get_conf_val dracut_args)" =~ (^|[[:space:]])--(gzip|bzip2|lzma|xz|lzo|lz4|zstd|no-compress|compress)([[:space:]]|$) ]]
 }
 
 # If "dracut_args" contains "--mount" information, use it
@@ -829,7 +828,7 @@ PROC_IOMEM=/proc/iomem
 get_system_size()
 {
 	sum=$(sed -n "s/\s*\([0-9a-fA-F]\+\)-\([0-9a-fA-F]\+\) : System RAM$/+ 0x\2 - 0x\1 + 1/p" $PROC_IOMEM)
-	echo $(( (sum) / 1024 / 1024 / 1024))
+	echo $(((sum) / 1024 / 1024 / 1024))
 }
 
 # Return the recommended size for the reserved crashkernel memory
@@ -927,7 +926,7 @@ get_luks_crypt_dev()
 
 	[[ -b /dev/block/$1 ]] || return 1
 
-	_type=$(blkid -u filesystem,crypto -o export -- "/dev/block/$1" | \
+	_type=$(blkid -u filesystem,crypto -o export -- "/dev/block/$1" |
 		sed -n -E "s/^TYPE=(.*)$/\1/p")
 	[[ $_type == "crypto_LUKS" ]] && echo "$1"
 

--- a/kdump-lib.sh
+++ b/kdump-lib.sh
@@ -119,6 +119,12 @@ is_dump_to_rootfs()
 	[[ $(kdump_get_conf_val 'failure_action\|default') == dump_to_rootfs ]]
 }
 
+is_lvm2_thinp_dump_target()
+{
+	_target=$(get_block_dump_target)
+	[ -n "$_target" ] && is_lvm2_thinp_device "$_target"
+}
+
 get_failure_action_target()
 {
 	local _target

--- a/kdump-logger.sh
+++ b/kdump-logger.sh
@@ -97,8 +97,11 @@ dlog_init()
 		kdump_stdloglvl=0
 		kdump_kmsgloglvl=0
 	else
+		# shellcheck disable=SC2153 # KDUMP_*LOGLVL is read from /etc/kdump/sysconfig by file that source kdump-logger.sh
 		kdump_stdloglvl=$KDUMP_STDLOGLVL
+		# shellcheck disable=SC2153
 		kdump_sysloglvl=$KDUMP_SYSLOGLVL
+		# shellcheck disable=SC2153
 		kdump_kmsgloglvl=$KDUMP_KMSGLOGLVL
 	fi
 

--- a/kdump-migrate-action.sh
+++ b/kdump-migrate-action.sh
@@ -2,7 +2,7 @@
 
 systemctl is-active kdump
 if [ $? -ne 0 ]; then
-        exit 0
+	exit 0
 fi
 
 /usr/lib/kdump/kdump-restart.sh

--- a/kdump-migrate-action.sh
+++ b/kdump-migrate-action.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 
-systemctl is-active kdump
-if [ $? -ne 0 ]; then
+if ! systemctl is-active kdump; then
 	exit 0
 fi
 

--- a/kdump-restart.sh
+++ b/kdump-restart.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 export PATH="$PATH:/usr/bin:/usr/sbin"
 
-exec >>/var/log/kdump-migration.log 2>&1
+exec >> /var/log/kdump-migration.log 2>&1
 
 echo "kdump: Partition Migration detected. Rebuilding initramfs image to reload."
 /usr/bin/kdumpctl rebuild

--- a/kdumpctl
+++ b/kdumpctl
@@ -390,6 +390,7 @@ check_files_modified()
 
 	# HOOKS is mandatory and need to check the modification time
 	files="$files $HOOKS"
+	is_lvm2_thinp_dump_target && files="$files $LVM_CONF"
 	check_exist "$files" && check_executable "$EXTRA_BINS" || return 2
 
 	for file in $files; do

--- a/kdumpctl
+++ b/kdumpctl
@@ -720,7 +720,7 @@ check_ssh_config()
 
 	[[ "${OPT[_fstype]}" == ssh ]] || return 0
 
-	target=$(ssh -G "${OPT[_target]}" | sed  -n -e "s/^hostname[[:space:]]\+\([^[:space:]]*\).*$/\1/p")
+	target=$(ssh -G "${OPT[_target]}" | sed -n -e "s/^hostname[[:space:]]\+\([^[:space:]]*\).*$/\1/p")
 	[[ ${OPT[_target]} =~ .*@.* ]] || return 1
 	if [[ ${OPT[_target]#*@} != "$target" ]]; then
 		derror "Invalid ssh destination ${OPT[_target]} provided."
@@ -788,7 +788,7 @@ propagate_ssh_key()
 
 	parse_config || return 1
 
-	if [[ ${OPT[_fstype]} != ssh ]] ; then
+	if [[ ${OPT[_fstype]} != ssh ]]; then
 		derror "No ssh destination defined in $KDUMP_CONFIG_FILE."
 		derror "Please verify that $KDUMP_CONFIG_FILE contains 'ssh <user>@<host>' and that it is properly formatted."
 		exit 1
@@ -1471,30 +1471,30 @@ reset_crashkernel()
 
 	for _opt in "$@"; do
 		case "$_opt" in
-			--fadump=*)
-				_val=${_opt#*=}
-				if _dump_mode=$(get_dump_mode_by_fadump_val $_val); then
-					_fadump_val=$_val
-				else
-					derror "failed to determine dump mode"
-					exit
-				fi
-				;;
-			--kernel=*)
-				_val=${_opt#*=}
-				if ! _valid_grubby_kernel_path $_val; then
-					derror "Invalid $_opt, please specify a valid kernel path, ALL or DEFAULT"
-					exit
-				fi
-				_grubby_kernel_path=$_val
-				;;
-			--reboot)
-				_reboot=yes
-				;;
-			*)
-				derror "$_opt not recognized"
-				exit 1
-				;;
+		--fadump=*)
+			_val=${_opt#*=}
+			if _dump_mode=$(get_dump_mode_by_fadump_val $_val); then
+				_fadump_val=$_val
+			else
+				derror "failed to determine dump mode"
+				exit
+			fi
+			;;
+		--kernel=*)
+			_val=${_opt#*=}
+			if ! _valid_grubby_kernel_path $_val; then
+				derror "Invalid $_opt, please specify a valid kernel path, ALL or DEFAULT"
+				exit
+			fi
+			_grubby_kernel_path=$_val
+			;;
+		--reboot)
+			_reboot=yes
+			;;
+		*)
+			derror "$_opt not recognized"
+			exit 1
+			;;
 		esac
 	done
 
@@ -1553,10 +1553,10 @@ reset_crashkernel()
 	if [[ -z $_grubby_kernel_path ]]; then
 		if [[ -z $KDUMP_KERNELVER ]] ||
 			! _kernel_path=$(_find_kernel_path_by_release "$KDUMP_KERNELVER"); then
-					if ! _kernel_path=$(_get_current_running_kernel_path); then
-						derror "no running kernel found"
-						exit 1
-					fi
+			if ! _kernel_path=$(_get_current_running_kernel_path); then
+				derror "no running kernel found"
+				exit 1
+			fi
 		fi
 		_kernels=$_kernel_path
 	else
@@ -1618,9 +1618,9 @@ update_crashkernel_in_grub_etc_default_after_update()
 	_new_default_crashkernel=${_crashkernel_vals[new_${_dump_mode}]}
 
 	if [[ $_crashkernel == auto ]] ||
-		  [[ $_crashkernel == "$_old_default_crashkernel" &&
-		     $_new_default_crashkernel != "$_old_default_crashkernel" ]]; then
-			_update_kernel_arg_in_grub_etc_default crashkernel "$_new_default_crashkernel"
+		[[ $_crashkernel == "$_old_default_crashkernel" &&
+			$_new_default_crashkernel != "$_old_default_crashkernel" ]]; then
+		_update_kernel_arg_in_grub_etc_default crashkernel "$_new_default_crashkernel"
 	fi
 }
 

--- a/mkdumprd
+++ b/mkdumprd
@@ -33,6 +33,7 @@ MKDUMPRD_TMPDIR="$(mktemp -d -t mkdumprd.XXXXXX)"
 [ -d "$MKDUMPRD_TMPDIR" ] || perror_exit "dracut: mktemp -p -d -t dracut.XXXXXX failed."
 MKDUMPRD_TMPMNT="$MKDUMPRD_TMPDIR/target"
 
+# shellcheck disable=SC2154 # known issue of shellcheck https://github.com/koalaman/shellcheck/issues/1299
 trap '
     ret=$?;
     is_mounted $MKDUMPRD_TMPMNT && umount -f $MKDUMPRD_TMPMNT;

--- a/mkfadumprd
+++ b/mkfadumprd
@@ -19,6 +19,8 @@ fi
 
 MKFADUMPRD_TMPDIR="$(mktemp -d -t mkfadumprd.XXXXXX)"
 [ -d "$MKFADUMPRD_TMPDIR" ] || perror_exit "mkfadumprd: mktemp -d -t mkfadumprd.XXXXXX failed."
+
+# shellcheck disable=SC2154 # known issue of shellcheck https://github.com/koalaman/shellcheck/issues/1299
 trap '
     ret=$?;
     [[ -d $MKFADUMPRD_TMPDIR ]] && rm --one-file-system -rf -- "$MKFADUMPRD_TMPDIR";

--- a/spec/kdumpctl_general_spec.sh
+++ b/spec/kdumpctl_general_spec.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# shellcheck disable=SC2286
+
 Describe 'kdumpctl'
 	Include ./kdumpctl
 

--- a/tests/scripts/build-image.sh
+++ b/tests/scripts/build-image.sh
@@ -54,4 +54,10 @@ img_add_qemu_cmd() {
 
 [ -e "$INST_SCRIPT" ] && source $INST_SCRIPT
 
+if [[ $USE_GUESTMOUNT ]]; then
+	# unmount the image before renaming it otherwise sync_guestunmount may falsely
+	# think that the image has been truely unmounted
+	sync_guestunmount $OUTPUT_IMAGE.building ${MNTS[$OUTPUT_IMAGE.building]}
+fi
+
 mv $OUTPUT_IMAGE.building $OUTPUT_IMAGE

--- a/tests/scripts/run-test.sh
+++ b/tests/scripts/run-test.sh
@@ -85,8 +85,7 @@ for test_case in $testcases; do
 	results[$test_case]="<Test Skipped>"
 
 	testdir=$TESTCASEDIR/$test_case
-	script_num=$(ls -1 $testdir | wc -l)
-	scripts=$(ls -r -1 $testdir | tr '\n' ' ')
+	scripts=$(ls -r -1 $testdir | egrep "\.sh$" | tr '\n' ' ')
 	test_outputs=""
 	read main_script aux_script <<< "$scripts"
 

--- a/tests/scripts/test-lib.sh
+++ b/tests/scripts/test-lib.sh
@@ -86,10 +86,16 @@ build_test_image() {
 }
 
 run_test_sync() {
-	local qemu_cmd=$(get_test_qemu_cmd $1)
+	local qemu_cmd=$(get_test_qemu_cmd $1) _timeout
+
+	if [[ $KUMP_TEST_QEMU_TIMEOUT ]]; then
+		_timeout=$KUMP_TEST_QEMU_TIMEOUT
+	else
+		_timeout=10m
+	fi
 
 	if [ -n "$qemu_cmd" ]; then
-		timeout --foreground 10m $BASEDIR/run-qemu $(get_test_qemu_cmd $1)
+		timeout --foreground $_timeout $BASEDIR/run-qemu $(get_test_qemu_cmd $1)
 	else
 		echo "error: test qemu command line is not configured" > /dev/stderr
 		return 1

--- a/tests/scripts/testcases/lvm2-thinp-kdump/0-local-lvm2-thinp.sh
+++ b/tests/scripts/testcases/lvm2-thinp-kdump/0-local-lvm2-thinp.sh
@@ -1,0 +1,59 @@
+on_build() {
+	TEST_DIR_PREFIX=/tmp/lvm_test.XXXXXX
+	# clear TEST_DIRs if any
+	rm -rf ${TEST_DIR_PREFIX%.*}.*
+	TEST_IMG="$(mktemp -d $TEST_DIR_PREFIX)/test.img"
+
+	img_inst_pkg "lvm2"
+	img_inst $TESTDIR/scripts/testcases/lvm2-thinp-kdump/lvm.conf  /etc/lvm/
+	dd if=/dev/zero of=$TEST_IMG bs=300M count=1
+	# The test.img will be /dev/sdb
+	img_add_qemu_cmd "-hdb $TEST_IMG"
+}
+
+on_test() {
+	VG=vg00
+	LV_THINPOOL=thinpool
+	LV_VOLUME=thinlv
+	VMCORE_PATH=var/crash
+
+	local boot_count=$(get_test_boot_count)
+
+	if [ $boot_count -eq 1 ]; then
+
+		vgcreate $VG /dev/sdb
+		# Create a small thinpool which is definitely not enough for
+		# vmcore, then create a thin volume which is definitely enough
+		# for vmcore, so we can make sure thinpool should be autoextend
+		# during runtime.
+		lvcreate -L 10M -T $VG/$LV_THINPOOL
+		lvcreate -V 300M -T $VG/$LV_THINPOOL -n $LV_VOLUME
+		mkfs.ext4 /dev/$VG/$LV_VOLUME
+		mount /dev/$VG/$LV_VOLUME /mnt
+		mkdir -p /mnt/$VMCORE_PATH
+
+		cat << EOF > /etc/kdump.conf
+ext4 /dev/$VG/$LV_VOLUME
+path /$VMCORE_PATH
+core_collector makedumpfile -l --message-level 7 -d 31
+EOF
+		kdumpctl start || test_failed "Failed to start kdump"
+
+		sync
+
+		echo 1 > /proc/sys/kernel/sysrq
+		echo c > /proc/sysrq-trigger
+
+	elif [ $boot_count -eq 2 ]; then
+		mount /dev/$VG/$LV_VOLUME /mnt
+		if has_valid_vmcore_dir /mnt/$VMCORE_PATH; then
+			test_passed
+		else
+			test_failed "Vmcore missing"
+		fi
+
+		shutdown -h 0
+	else
+		test_failed "Unexpected reboot"
+	fi
+}

--- a/tests/scripts/testcases/lvm2-thinp-kdump/lvm.conf
+++ b/tests/scripts/testcases/lvm2-thinp-kdump/lvm.conf
@@ -1,0 +1,5 @@
+activation {
+	thin_pool_autoextend_threshold = 70
+	thin_pool_autoextend_percent = 20
+	monitoring = 1
+}

--- a/tests/scripts/testcases/nfs-kdump/0-server.sh
+++ b/tests/scripts/testcases/nfs-kdump/0-server.sh
@@ -16,12 +16,13 @@ on_build() {
 	img_run_cmd "echo dhcp-range=192.168.77.50,192.168.77.100,255.255.255.0,12h >> /etc/dnsmasq.conf"
 	img_run_cmd "systemctl enable dnsmasq"
 
-	img_run_cmd 'echo DEVICE="eth0" > /etc/sysconfig/network-scripts/ifcfg-eth0'
-	img_run_cmd 'echo BOOTPROTO="none" >> /etc/sysconfig/network-scripts/ifcfg-eth0'
-	img_run_cmd 'echo ONBOOT="yes" >> /etc/sysconfig/network-scripts/ifcfg-eth0'
-	img_run_cmd 'echo PREFIX="24" >> /etc/sysconfig/network-scripts/ifcfg-eth0'
-	img_run_cmd 'echo IPADDR="192.168.77.1" >> /etc/sysconfig/network-scripts/ifcfg-eth0'
-	img_run_cmd 'echo TYPE="Ethernet" >> /etc/sysconfig/network-scripts/ifcfg-eth0'
+	img_run_cmd 'echo [connection] > /etc/NetworkManager/system-connections/eth0.nmconnection'
+	img_run_cmd 'echo type=ethernet >> /etc/NetworkManager/system-connections/eth0.nmconnection'
+	img_run_cmd 'echo interface-name=eth0 >> /etc/NetworkManager/system-connections/eth0.nmconnection'
+	img_run_cmd 'echo [ipv4] >> /etc/NetworkManager/system-connections/eth0.nmconnection'
+	img_run_cmd 'echo address1=192.168.77.1/24 >> /etc/NetworkManager/system-connections/eth0.nmconnection'
+	img_run_cmd 'echo method=manual >> /etc/NetworkManager/system-connections/eth0.nmconnection'
+	img_run_cmd 'chmod 600 /etc/NetworkManager/system-connections/eth0.nmconnection'
 
 	img_add_qemu_cmd "-nic socket,listen=:8010,mac=52:54:00:12:34:56"
 }

--- a/tests/scripts/testcases/ssh-kdump/0-server.sh
+++ b/tests/scripts/testcases/ssh-kdump/0-server.sh
@@ -17,12 +17,13 @@ on_build() {
 	img_run_cmd "echo dhcp-range=192.168.77.50,192.168.77.100,255.255.255.0,12h >> /etc/dnsmasq.conf"
 	img_run_cmd "systemctl enable dnsmasq"
 
-	img_run_cmd 'echo DEVICE="eth0" > /etc/sysconfig/network-scripts/ifcfg-eth0'
-	img_run_cmd 'echo BOOTPROTO="none >> /etc/sysconfig/network-scripts/ifcfg-eth0"'
-	img_run_cmd 'echo ONBOOT="yes" >> /etc/sysconfig/network-scripts/ifcfg-eth0'
-	img_run_cmd 'echo PREFIX="24" >> /etc/sysconfig/network-scripts/ifcfg-eth0'
-	img_run_cmd 'echo IPADDR="192.168.77.1" >> /etc/sysconfig/network-scripts/ifcfg-eth0'
-	img_run_cmd 'echo TYPE="Ethernet" >> /etc/sysconfig/network-scripts/ifcfg-eth0'
+	img_run_cmd 'echo [connection] > /etc/NetworkManager/system-connections/eth0.nmconnection'
+	img_run_cmd 'echo type=ethernet >> /etc/NetworkManager/system-connections/eth0.nmconnection'
+	img_run_cmd 'echo interface-name=eth0 >> /etc/NetworkManager/system-connections/eth0.nmconnection'
+	img_run_cmd 'echo [ipv4] >> /etc/NetworkManager/system-connections/eth0.nmconnection'
+	img_run_cmd 'echo address1=192.168.77.1/24 >> /etc/NetworkManager/system-connections/eth0.nmconnection'
+	img_run_cmd 'echo method=manual >> /etc/NetworkManager/system-connections/eth0.nmconnection'
+	img_run_cmd 'chmod 600 /etc/NetworkManager/system-connections/eth0.nmconnection'
 }
 
 # Executed when VM boots

--- a/tools/run-integration-tests.sh
+++ b/tools/run-integration-tests.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -ex
+
+[[ -d ${0%/*} ]] && cd "${0%/*}"/../
+
+source /etc/os-release
+
+cd tests
+
+# fedpkg fetch sources based on branch.f$VERSION_ID.remote
+if ! grep -q fedora_src <(git remote show); then
+	git remote add fedora_src https://src.fedoraproject.org/rpms/kexec-tools.git
+fi
+git config --add branch.f$VERSION_ID.remote fedora_src
+
+can_we_use_qemu_nbd()
+{
+	_tmp_img=/tmp/test.qcow2
+
+	(sudo -v && sudo modprobe nbd \
+		&& qemu-img create -fqcow2 $_tmp_img 10m \
+		&& qemu-nbd -c /dev/nbd0 $_tmp_img && sudo qemu-nbd -d /dev/nbd0 && rm $_tmp_img) &> /dev/null
+}
+
+if ! can_we_use_qemu_nbd; then
+	USE_GUESTMOUNT=1
+fi
+
+KUMP_TEST_QEMU_TIMEOUT=20m USE_GUESTMOUNT=$USE_GUESTMOUNT BASE_IMAGE=/usr/share/cloud_images/Fedora-Cloud-Base-36-1.5.x86_64.qcow2 RELEASE=$VERSION_ID make test-run


### PR DESCRIPTION
Thin provision is a mechanism that you can allocate a lvm volume which has
a large virtual size for file systems but actually in a small physical
size. The physical size can be autoextended in use if thin pool reached a
threshold specified in /etc/lvm/lvm.conf.

There are 2 works should be handled when enable lvm2 thinp for kdump:

1) Check if the dump target device or directory is thinp device.
2) Monitor the thin pool and autoextend its size when it reached the threshold
   during kdump.

According to my testing, the memory consumption procedure for lvm2 thinp is the thin pool
size-autoextend phase. For fedora and rhel9, the default crashkernel value is enough. But
for rhel8, the default crashkernel value 1G-4G:160M is not enough, so it should
be handled particularly.

v1 -> v2:

1) Modified the usage of lvs cmd when check if target is lvm2 thinp
   device.
2) Removed the sync flag way of mounting for lvm2 thinp target
   during kdump, use "sync -f vmcore" to force sync data, and handle
   the error if fails.

v2 -> v3:

1) Removed "sync -f vmcore" patch out of the patch set, for it is
addressing an issue which is not specifically to lvm2 thinp support for
kdump.

v3 -> v4:

1) Removed lvm2-monitor.service, implemented the monitor service with
   a loop function within a shell script instead.
2) Add lvm2 thinp support for dump_raw, for it is addressing the similar
   issue as dump_fs.
3) Dave suggested me to implement the lvm2 thin support in dracut
   modules instead of kexec-tools. If you are OK with the loop-function-shell-script
   technical way, I will give a try to migrate it to dracut.

v4 -> v5:

1) A new 80lvmthinpool-monitor module [1] has been integrated in dracut.
   Now we simply depend on it.
2) Add lvm2 thin provision selftest.

[1]: https://github.com/dracutdevs/dracut/pull/1842

v5 -> v6:

1) Code refactoring based on Philipp's comments.
2) Print warning if lvmthinpool-monitor module is not exist.

Tao Liu (5):
  Add lvm2 thin provision dump target checker
  lvm.conf should be check modified if lvm2 thinp enabled
  Add dependency of dracut lvmthinpool-monitor module
  selftest: Only iterate the .sh files for test execution
  selftest: Add lvm2 thin provision for kdump test

 dracut-module-setup.sh                        |  8 +++
 kdump-lib-initramfs.sh                        | 10 ++++
 kdump-lib.sh                                  |  6 ++
 kdumpctl                                      |  1 +
 tests/scripts/run-test.sh                     |  3 +-
 .../lvm2-thinp-kdump/0-local-lvm2-thinp.sh    | 59 +++++++++++++++++++
 .../testcases/lvm2-thinp-kdump/lvm.conf       |  5 ++
 7 files changed, 90 insertions(+), 2 deletions(-)
 create mode 100755 tests/scripts/testcases/lvm2-thinp-kdump/0-local-lvm2-thinp.sh
 create mode 100644 tests/scripts/testcases/lvm2-thinp-kdump/lvm.conf
